### PR TITLE
Redid some stuff on the one ring, mostly to prevent problems with pla…

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -1,5 +1,5 @@
 package_group=emt
 mc_version=1.7.10
 forge_version=10.13.4.1614
-mod_version=1.2.6.6
+mod_version=1.2.6.7
 mod_name=ElectroMagicTools


### PR DESCRIPTION
Suggestion for the one Ring:

- It prints now a couple of messages while applying effects, to let you know stuff is going on
The Ring itself "accumulates" Item-Warp, can raise unlimited. by a chance of 1:2000, and only if corruption is >= 300. This is to render the item useless / extremely dangerous after a while
- The first stage of effects is now 300
- Reduced the "tick every tick" behavior to "tick about once per second"; Thus 300 corruption equals to about 300 Seconds
- The Ring removal is... tricky. It "does not want to be removed"
Better than the old "can't remove the ring for 600 ticks" logic
- Potentially fixed a problem with writing the PlayerProfile; It appeared that it tries to remove the entire "ForgeData" subtag ?!
- Corruption was reset once you put the ring back on/put a second ring on. This is now gone. Corruption is persisted, forever.
- Reenabled invincibility, as the ring now is limited by itself, and in general even if you happen to find more than one