### PR TITLE
fixed gens outputting their amps up to 6 times

### DIFF
--- a/src/main/java/emt/tile/generator/TileEntityBaseGenerator.java
+++ b/src/main/java/emt/tile/generator/TileEntityBaseGenerator.java
@@ -336,18 +336,19 @@ public class TileEntityBaseGenerator
         if (!side)
             return;
 
-        boolean foundGregTechTile = false;
-
-        for (byte i = 0; i < 6; i = (byte) (i + 1)) {
-            if (getIGregTechTileEntityAtSide(i) != null) {
-                foundGregTechTile = true;
-            }
-        }
-
-        if (foundGregTechTile && isUniversalEnergyStored(getOutputVoltage() * getOutputAmperage())) {
+        if (checkForGtTile() && isUniversalEnergyStored(getOutputVoltage() * getOutputAmperage())) {
             long tEU = IEnergyConnected.Util.emitEnergyToNetwork(getOutputVoltage(), getOutputAmperage(), this);
             drainEnergyUnits((byte) 0, getOutputVoltage(), tEU);
         }
+    }
+
+    private boolean checkForGtTile() {
+        for (byte i = 0; i < 6; i = (byte) (i + 1)) {
+            if (getIGregTechTileEntityAtSide(i) != null) {
+                return true;
+            }
+        }
+        return false;
     }
 
     public byte getColorization() {

--- a/src/main/java/emt/tile/generator/TileEntityBaseGenerator.java
+++ b/src/main/java/emt/tile/generator/TileEntityBaseGenerator.java
@@ -336,13 +336,17 @@ public class TileEntityBaseGenerator
         if (!side)
             return;
 
+        boolean foundGregTechTile = false;
+
         for (byte i = 0; i < 6; i = (byte) (i + 1)) {
             if (getIGregTechTileEntityAtSide(i) != null) {
-                if (isUniversalEnergyStored(getOutputVoltage() * getOutputAmperage())) {
-                    long tEU = IEnergyConnected.Util.emitEnergyToNetwork(getOutputVoltage(), getOutputAmperage(), this);
-                    drainEnergyUnits(i, getOutputVoltage(), tEU);
-                }
+                foundGregTechTile = true;
             }
+        }
+
+        if (foundGregTechTile && isUniversalEnergyStored(getOutputVoltage() * getOutputAmperage())) {
+            long tEU = IEnergyConnected.Util.emitEnergyToNetwork(getOutputVoltage(), getOutputAmperage(), this);
+            drainEnergyUnits((byte) 0, getOutputVoltage(), tEU);
         }
     }
 

--- a/src/main/java/emt/tile/solar/TileEntitySolarBase.java
+++ b/src/main/java/emt/tile/solar/TileEntitySolarBase.java
@@ -379,13 +379,17 @@ public class TileEntitySolarBase extends TileEntityEMT implements IInventory, IW
     }
 
     public void inputintoGTnet() {
+        boolean foundGregTechTile = false;
+
         for (byte i = 0; i < 6; i = (byte) (i + 1)) {
             if (getIGregTechTileEntityAtSide(i) != null) {
-                if (isUniversalEnergyStored(getOutputVoltage() * getOutputAmperage())) {
-                    long tEU = IEnergyConnected.Util.emitEnergyToNetwork(getOutputVoltage(), getOutputAmperage(), this);
-                    drainEnergyUnits(i, getOutputVoltage(), tEU);
-                }
+                foundGregTechTile = true;
             }
+        }
+
+        if (foundGregTechTile && isUniversalEnergyStored(getOutputVoltage() * getOutputAmperage())) {
+            long tEU = IEnergyConnected.Util.emitEnergyToNetwork(getOutputVoltage(), getOutputAmperage(), this);
+            drainEnergyUnits((byte) 0, getOutputVoltage(), tEU);
         }
     }
 

--- a/src/main/java/emt/tile/solar/TileEntitySolarBase.java
+++ b/src/main/java/emt/tile/solar/TileEntitySolarBase.java
@@ -379,18 +379,22 @@ public class TileEntitySolarBase extends TileEntityEMT implements IInventory, IW
     }
 
     public void inputintoGTnet() {
-        boolean foundGregTechTile = false;
+        if (!side)
+            return;
 
-        for (byte i = 0; i < 6; i = (byte) (i + 1)) {
-            if (getIGregTechTileEntityAtSide(i) != null) {
-                foundGregTechTile = true;
-            }
-        }
-
-        if (foundGregTechTile && isUniversalEnergyStored(getOutputVoltage() * getOutputAmperage())) {
+        if (checkForGtTile() && isUniversalEnergyStored(getOutputVoltage() * getOutputAmperage())) {
             long tEU = IEnergyConnected.Util.emitEnergyToNetwork(getOutputVoltage(), getOutputAmperage(), this);
             drainEnergyUnits((byte) 0, getOutputVoltage(), tEU);
         }
+    }
+
+    private boolean checkForGtTile() {
+        for (byte i = 0; i < 6; i = (byte) (i + 1)) {
+            if (getIGregTechTileEntityAtSide(i) != null) {
+                return true;
+            }
+        }
+        return false;
     }
 
     public byte getColorization() {


### PR DESCRIPTION
Essentia generators were outputting their amps for every adjacent GT tile entity they found, so a 3A gen would output up to 18A into a single cable. This caused cables to be burnt.