### PR TITLE
Finalize build script

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -1,5 +1,0 @@
-package_group=emt
-mc_version=1.7.10
-forge_version=10.13.4.1614
-mod_version=1.2.8.4
-mod_name=ElectroMagicTools

--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -2,17 +2,9 @@
 
 dependencies {
     compile("com.github.GTNewHorizons:GT5-Unofficial:master-SNAPSHOT:dev")
-    compile("com.github.GTNewHorizons:CodeChickenLib:master-SNAPSHOT:dev")
-    compile("com.github.GTNewHorizons:CodeChickenCore:master-SNAPSHOT:dev")
     compile("com.github.GTNewHorizons:StructureLib:master-SNAPSHOT:dev")
-    compile("com.github.GTNewHorizons:NotEnoughItems:master-SNAPSHOT:dev")
-    compile("net.industrial-craft:industrialcraft-2:2.2.828-experimental:dev")
-    
-    compileOnly("com.github.GTNewHorizons:Galacticraft:master-SNAPSHOT:dev") {
-        transitive = false
-    }
-    compileOnly("com.github.GTNewHorizons:Baubles:master-SNAPSHOT:dev") {
-        transitive = false
-    }
+    compile("com.github.GTNewHorizons:Baubles:master-SNAPSHOT:dev")
 
+    compile("net.industrial-craft:industrialcraft-2:2.2.828-experimental:dev")
+    compile("thaumcraft:Thaumcraft:1.7.10-4.2.3.5:dev")
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -27,10 +27,10 @@ developmentEnvironmentUserName = Developer
 # version in @Mod([...], version = VERSION, [...])
 # Leave these properties empty to skip individual token replacements
 replaceGradleTokenInFile = EMT.java
-gradleTokenModId = GRADLETOKEN_MODID
-gradleTokenModName = GRADLETOKEN_MODNAME
+gradleTokenModId =
+gradleTokenModName =
 gradleTokenVersion = GRADLETOKEN_VERSION
-gradleTokenGroupName = GRADLETOKEN_GROUPNAME
+gradleTokenGroupName =
 
 # In case your mod provides an API for other mods to implement you may declare its package here. Otherwise, you can
 # leave this property empty.

--- a/src/main/java/emt/EMT.java
+++ b/src/main/java/emt/EMT.java
@@ -31,8 +31,8 @@ import org.apache.logging.log4j.Logger;
         dependencies = EMT.DEPENDS
 )
 public class EMT {
-    public static final String NAME = "GRADLETOKEN_MODNAME";
-    public static final String MOD_ID = "GRADLETOKEN_MODID";
+    public static final String NAME = "Electro-Magic Tools";
+    public static final String MOD_ID = "EMT";
     public static final String VERSION = "GRADLETOKEN_VERSION";
     public static final String TEXTURE_PATH = "emt";
     public static final String GUI_FACTORY = "emt.client.gui.config.EMTGuiFactory";

--- a/src/main/resources/mcmod.info
+++ b/src/main/resources/mcmod.info
@@ -1,7 +1,7 @@
 [
   {
     "modid": "${modId}",
-    "name": "Electro-Magic Tools",
+    "name": "${modName}",
     "description": "Ever thought about combining magic and electricity?",
     "version": "${modVersion}",
     "mcversion": "${minecraftVersion}",


### PR DESCRIPTION
Few pointers:
- clean up all old build script files
- Don't use GRADLETOKEN_MODNAME, GRADLETOKEN_MODID, GRADLETOKEN_GROUPNAME
- Remove the tokens in gradle.properties if unused. It will disable the replacement
- Use all for tokens for mcmod.info (modId, modName, modVersion, minecraftVersion)
- Remove all jars in /libs. They are added manually and it is easy to loose track of those. Have all dependencies added in a single place. If you need any jars, place them under dependencies and specify them explicitly in dependencies.gradle
- Remove all dependencies not referenced in the code. Just global search for the top-level package name)
- Run the project to verify its dependency configuration. It was missing Baubles.