### PR TITLE
keybinds

### DIFF
--- a/src/main/java/emt/client/EMTKeys.java
+++ b/src/main/java/emt/client/EMTKeys.java
@@ -1,6 +1,7 @@
 package emt.client;
 
 import cpw.mods.fml.client.registry.ClientRegistry;
+import emt.EMT;
 import emt.util.EMTTextHelper;
 import net.minecraft.client.settings.KeyBinding;
 import org.lwjgl.input.Keyboard;
@@ -9,7 +10,7 @@ public class EMTKeys {
     public static KeyBinding keyUnequip;
 
     public static void registerKeys() {
-        keyUnequip = new KeyBinding(EMTTextHelper.localize("gui.EMT.key.unequip"), Keyboard.KEY_Z, "EMT");
+        keyUnequip = new KeyBinding(EMTTextHelper.localize("gui.EMT.key.unequip"), Keyboard.KEY_NONE, EMT.NAME);
         ClientRegistry.registerKeyBinding(keyUnequip);
     }
 }

--- a/src/main/java/emt/util/EMTClientEventHandler.java
+++ b/src/main/java/emt/util/EMTClientEventHandler.java
@@ -21,7 +21,7 @@ public class EMTClientEventHandler {
 
     @SubscribeEvent
     public void clientTick(ClientTickEvent e) {
-        if (EMTKeys.keyUnequip.getIsKeyPressed()) {
+        if (EMTKeys.keyUnequip.isPressed()) {
             EMT.INSTANCE.sendToServer(new PacketEMTKeys());
         }
     }


### PR DESCRIPTION
The goal is to unbind all keys that are not used from the start of the game in the GTNH modpack to avoid all the current keybinds conflict and leave to the user the choice of the keybinds they want.