### PR TITLE
Fix maintenance focus NPE

### DIFF
--- a/src/main/java/emt/item/focus/ItemMaintenanceFocus.java
+++ b/src/main/java/emt/item/focus/ItemMaintenanceFocus.java
@@ -46,6 +46,7 @@ public class ItemMaintenanceFocus extends ItemBaseFocus {
     @Override
     public ItemStack onFocusRightClick(ItemStack itemStack, World world, EntityPlayer player,
             MovingObjectPosition mop) {
+        if (mop == null) return itemStack;
 
         ItemWandCasting wand = (ItemWandCasting) itemStack.getItem();
 


### PR DESCRIPTION
Fixes `java.lang.NullPointerException: Cannot read field "blockX" because "mop" is null`