### PR TITLE
Make boots apply speed boost to all directions

### DIFF
--- a/src/main/java/emt/item/armor/boots/ItemElectricBootsTraveller.java
+++ b/src/main/java/emt/item/armor/boots/ItemElectricBootsTraveller.java
@@ -122,7 +122,7 @@ public class ItemElectricBootsTraveller extends ItemArmor
 
     @Override
     public void onArmorTick(World world, EntityPlayer player, ItemStack itemStack) {
-        if (!player.capabilities.isFlying && player.moveForward > 0.0F) {
+        if (!player.capabilities.isFlying && (player.moveForward != 0.0F || player.moveStrafing != 0.0F)) {
             if (player.worldObj.isRemote && !player.isSneaking()) {
                 if (!Thaumcraft.instance.entityEventHandler.prevStep.containsKey(player.getEntityId())) {
                     Thaumcraft.instance.entityEventHandler.prevStep.put(player.getEntityId(), player.stepHeight);
@@ -140,7 +140,7 @@ public class ItemElectricBootsTraveller extends ItemArmor
                     bonus /= 2.0F;
                 }
 
-                player.moveFlying(0.0F, 1.0F, bonus);
+                player.moveFlying(player.moveStrafing, player.moveForward, bonus);
             } else if (Hover.getHover(player.getEntityId())) {
                 // Base ItemBootsTraveller jumpBonus equals to jumpBonus of Electric Boots,
                 // so any other boots factor can be calculated via proportion method


### PR DESCRIPTION
Currently they only boost going forwards, this makes them apply the same speed boost to all directions.

Sibling PR of https://github.com/GTNewHorizons/ThaumicBoots/pull/24