### PR TITLE
Reset fall damage when holding shift or space with wings

### DIFF
--- a/src/main/java/emt/item/armor/chestplate/ItemInfusedQuantumChestplate.java
+++ b/src/main/java/emt/item/armor/chestplate/ItemInfusedQuantumChestplate.java
@@ -534,6 +534,7 @@ public class ItemInfusedQuantumChestplate extends ItemArmorElectric implements I
 
         if (isJumping && !player.onGround && player.motionY < 0) {
             player.motionY *= f1;
+            player.fallDistance = 0;
         }
 
         if (player.isInWater() && !player.capabilities.isCreativeMode) {
@@ -555,9 +556,6 @@ public class ItemInfusedQuantumChestplate extends ItemArmorElectric implements I
 
         if (player.isSneaking() && !player.onGround && player.motionY < 0) {
             player.motionY *= 0.6;
-        }
-
-        if (player.fallDistance > 0.0F) {
             player.fallDistance = 0;
         }
     }

--- a/src/main/java/emt/item/armor/wings/ItemFeatherWing.java
+++ b/src/main/java/emt/item/armor/wings/ItemFeatherWing.java
@@ -107,6 +107,7 @@ public class ItemFeatherWing extends ItemArmor implements IRunicArmor {
 
         if (isJumping && !player.onGround && player.motionY < 0) {
             player.motionY *= f1;
+            player.fallDistance = 0;
         }
 
         if (player.isInWater() && !player.capabilities.isCreativeMode) {
@@ -124,6 +125,7 @@ public class ItemFeatherWing extends ItemArmor implements IRunicArmor {
 
         if (player.isSneaking() && !player.onGround && player.motionY < 0) {
             player.motionY *= 0.6;
+            player.fallDistance = 0;
         }
     }
 


### PR DESCRIPTION
1. For regular wings, reset fall damage when pressing shift or space. Cause old behavior is, frankly, dumb.
2. Modify infused chestplate behavior with wings to copy regular wings. It used to constantly reset fall damage with wings on, that was also silly