### PR TITLE
EMT Foci Bugfixes/Cleanup

### DIFF
--- a/src/main/java/emt/item/focus/ItemBaseFocus.java
+++ b/src/main/java/emt/item/focus/ItemBaseFocus.java
@@ -85,11 +85,6 @@ public abstract class ItemBaseFocus extends ItemFocusBasic {
     public void onPlayerStoppedUsingFocus(ItemStack itemstack, World world, EntityPlayer player, int count) {}
 
     @Override
-    public String getSortingHelper(ItemStack itemstack) {
-        return "00";
-    }
-
-    @Override
     public boolean onFocusBlockStartBreak(ItemStack itemstack, int x, int y, int z, EntityPlayer player) {
         return false;
     }

--- a/src/main/java/emt/item/focus/ItemBaseFocus.java
+++ b/src/main/java/emt/item/focus/ItemBaseFocus.java
@@ -67,10 +67,6 @@ public abstract class ItemBaseFocus extends ItemFocusBasic {
         return isVisCostPerTick(stack);
     }
 
-    public boolean isVisCostPerTick() {
-        return false;
-    }
-
     @Override
     public ItemStack onFocusRightClick(ItemStack paramItemStack, World paramWorld, EntityPlayer paramEntityPlayer,
             MovingObjectPosition paramMovingObjectPosition) {

--- a/src/main/java/emt/item/focus/ItemBaseFocus.java
+++ b/src/main/java/emt/item/focus/ItemBaseFocus.java
@@ -34,20 +34,6 @@ public abstract class ItemBaseFocus extends ItemFocusBasic {
         this.icon = ir.registerIcon(EMT.TEXTURE_PATH + ":" + "focus_" + textureName);
     }
 
-    boolean hasDepth() {
-        return false;
-    }
-
-    @Override
-    public int getFocusColor(ItemStack stack) {
-        return 0;
-    }
-
-    @Override
-    public boolean isItemTool(ItemStack par1ItemStack) {
-        return true;
-    }
-
     @Override
     public EnumRarity getRarity(ItemStack itemstack) {
         return EnumRarity.rare;
@@ -63,14 +49,10 @@ public abstract class ItemBaseFocus extends ItemFocusBasic {
         return new AspectList();
     }
 
-    public boolean isUseItem(ItemStack stack) {
-        return isVisCostPerTick(stack);
-    }
-
     @Override
     public ItemStack onFocusRightClick(ItemStack paramItemStack, World paramWorld, EntityPlayer paramEntityPlayer,
             MovingObjectPosition paramMovingObjectPosition) {
-        if (isUseItem(paramItemStack)) paramEntityPlayer.setItemInUse(paramItemStack, Integer.MAX_VALUE);
+        if (isVisCostPerTick(paramItemStack)) paramEntityPlayer.setItemInUse(paramItemStack, Integer.MAX_VALUE);
         return paramItemStack;
     }
 

--- a/src/main/java/emt/item/focus/ItemBaseFocus.java
+++ b/src/main/java/emt/item/focus/ItemBaseFocus.java
@@ -89,9 +89,4 @@ public abstract class ItemBaseFocus extends ItemFocusBasic {
         return false;
     }
 
-    @Override
-    public int getItemEnchantability() {
-        return 5;
-    }
-
 }

--- a/src/main/java/emt/item/focus/ItemChargeFocus.java
+++ b/src/main/java/emt/item/focus/ItemChargeFocus.java
@@ -56,7 +56,7 @@ public class ItemChargeFocus extends ItemBaseFocus {
             MovingObjectPosition movingobjectposition) {
         ItemWandCasting wand = (ItemWandCasting) itemstack.getItem();
         if (player.capabilities.isCreativeMode
-                || wand.consumeAllVis(itemstack, player, getVisCost(itemstack), true, true)) {
+                || wand.consumeAllVis(itemstack, player, getVisCost(itemstack), true, false)) {
             if (!world.isRemote) {
 
                 int energyLeft = (int) (EMTConfigHandler.chargeFocusProduction

--- a/src/main/java/emt/item/focus/ItemChargeFocus.java
+++ b/src/main/java/emt/item/focus/ItemChargeFocus.java
@@ -1,10 +1,12 @@
 package emt.item.focus;
 
+import java.util.List;
 import java.util.Map.Entry;
 
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.MovingObjectPosition;
+import net.minecraft.util.StatCollector;
 import net.minecraft.world.World;
 
 import emt.util.EMTConfigHandler;
@@ -35,7 +37,7 @@ public class ItemChargeFocus extends ItemBaseFocus {
         for (Entry<Aspect, Integer> e : visCost.aspects.entrySet()) actualCost.add(
                 e.getKey(),
                 (int) (e.getValue() * Math.pow(1.1, getUpgradeLevel(stack, FocusUpgradeType.potency))));
-        return visCost;
+        return actualCost;
     }
 
     @Override
@@ -47,10 +49,6 @@ public class ItemChargeFocus extends ItemBaseFocus {
         return new FocusUpgradeType[] { FocusUpgradeType.potency, FocusUpgradeType.frugal };
     }
 
-    public boolean canApplyUpgrade(ItemStack focusstack, EntityPlayer player, FocusUpgradeType type, int rank) {
-        return true;
-    }
-
     @Override
     public ItemStack onFocusRightClick(ItemStack itemstack, World world, EntityPlayer player,
             MovingObjectPosition movingobjectposition) {
@@ -59,8 +57,7 @@ public class ItemChargeFocus extends ItemBaseFocus {
                 || wand.consumeAllVis(itemstack, player, getVisCost(itemstack), true, false)) {
             if (!world.isRemote) {
 
-                int energyLeft = (int) (EMTConfigHandler.chargeFocusProduction
-                        * Math.pow(1.1, getUpgradeLevel(itemstack, FocusUpgradeType.potency)));
+                int energyLeft = getChargeRate(itemstack);
                 for (int i = 0; i < player.inventory.armorInventory.length; i++) {
                     if (energyLeft > 0) {
                         if ((player.inventory.armorInventory[i] != null)
@@ -88,5 +85,17 @@ public class ItemChargeFocus extends ItemBaseFocus {
             }
         }
         return itemstack;
+    }
+
+    private int getChargeRate(ItemStack itemstack) {
+        return (int) (EMTConfigHandler.chargeFocusProduction
+                * Math.pow(1.1, getUpgradeLevel(itemstack, FocusUpgradeType.potency)));
+    }
+
+    @Override
+    public void addInformation(ItemStack stack, EntityPlayer player, List list, boolean par4) {
+        list.add(StatCollector.translateToLocal("item.EMT.focus.EU.cost.info"));
+        list.add(StatCollector.translateToLocalFormatted("item.EMT.focus.EU.cost.once", getChargeRate(stack)));
+        super.addInformation(stack, player, list, par4);
     }
 }

--- a/src/main/java/emt/item/focus/ItemChargeFocus.java
+++ b/src/main/java/emt/item/focus/ItemChargeFocus.java
@@ -40,7 +40,7 @@ public class ItemChargeFocus extends ItemBaseFocus {
 
     @Override
     public String getSortingHelper(ItemStack itemstack) {
-        return "WANDCHARGING";
+        return "WANDCHARGING" + super.getSortingHelper(itemstack);
     }
 
     public FocusUpgradeType[] getPossibleUpgradesByRank(ItemStack focusstack, int rank) {

--- a/src/main/java/emt/item/focus/ItemChristmasFocus.java
+++ b/src/main/java/emt/item/focus/ItemChristmasFocus.java
@@ -42,7 +42,7 @@ public class ItemChristmasFocus extends ItemBaseFocus {
             int y = mop.blockY + 1;
             int z = mop.blockZ;
             if (player.capabilities.isCreativeMode
-                    || wand.consumeAllVis(itemstack, player, getVisCost(itemstack), true, true)) {
+                    || wand.consumeAllVis(itemstack, player, getVisCost(itemstack), true, false)) {
                 if (!world.isRemote) {
                     EntitySnowman snowman;
                     snowman = new EntitySnowman(world);

--- a/src/main/java/emt/item/focus/ItemChristmasFocus.java
+++ b/src/main/java/emt/item/focus/ItemChristmasFocus.java
@@ -30,7 +30,7 @@ public class ItemChristmasFocus extends ItemBaseFocus {
 
     @Override
     public String getSortingHelper(ItemStack itemstack) {
-        return "CHRISTMAS";
+        return "CHRISTMAS" + super.getSortingHelper(itemstack);
     }
 
     @Override

--- a/src/main/java/emt/item/focus/ItemChristmasFocus.java
+++ b/src/main/java/emt/item/focus/ItemChristmasFocus.java
@@ -8,6 +8,7 @@ import net.minecraft.world.World;
 
 import thaumcraft.api.aspects.Aspect;
 import thaumcraft.api.aspects.AspectList;
+import thaumcraft.api.wands.FocusUpgradeType;
 import thaumcraft.common.items.wands.ItemWandCasting;
 
 public class ItemChristmasFocus extends ItemBaseFocus {
@@ -31,6 +32,11 @@ public class ItemChristmasFocus extends ItemBaseFocus {
     @Override
     public String getSortingHelper(ItemStack itemstack) {
         return "CHRISTMAS" + super.getSortingHelper(itemstack);
+    }
+
+    @Override
+    public FocusUpgradeType[] getPossibleUpgradesByRank(ItemStack focusstack, int rank) {
+        return new FocusUpgradeType[] { FocusUpgradeType.frugal };
     }
 
     @Override

--- a/src/main/java/emt/item/focus/ItemEnergyBallFocus.java
+++ b/src/main/java/emt/item/focus/ItemEnergyBallFocus.java
@@ -1,13 +1,17 @@
 package emt.item.focus;
 
+import java.util.List;
+
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.util.MathHelper;
 import net.minecraft.util.MovingObjectPosition;
+import net.minecraft.util.StatCollector;
 import net.minecraft.world.World;
 
 import emt.entity.EntityEnergyBall;
 import ic2.api.item.ElectricItem;
+import thaumcraft.api.wands.FocusUpgradeType;
 
 public class ItemEnergyBallFocus extends ItemBaseFocus {
 
@@ -26,6 +30,11 @@ public class ItemEnergyBallFocus extends ItemBaseFocus {
     }
 
     @Override
+    public FocusUpgradeType[] getPossibleUpgradesByRank(ItemStack focusstack, int rank) {
+        return new FocusUpgradeType[] { FocusUpgradeType.frugal };
+    }
+
+    @Override
     public ItemStack onFocusRightClick(ItemStack stack, World world, EntityPlayer player, MovingObjectPosition mop) {
         if (world.isRemote) {
             return stack;
@@ -36,9 +45,11 @@ public class ItemEnergyBallFocus extends ItemBaseFocus {
             return stack;
         }
 
-        double val = ElectricItem.manager.discharge(armor, 5120, 4, true, false, false);
+        // 10% discount per level of frugal
+        int cost = getCost(stack);
+        double val = ElectricItem.manager.discharge(armor, cost, 4, true, false, false);
 
-        if (val < 5120) {
+        if (val < cost) {
             return stack;
         }
 
@@ -50,5 +61,19 @@ public class ItemEnergyBallFocus extends ItemBaseFocus {
         world.spawnEntityInWorld(new EntityEnergyBall(world, player, rotX, rotY, rotZ));
 
         return stack;
+    }
+
+    /**
+     * Base cost of 5120 with a 10% discount per level of frugal.
+     */
+    private int getCost(ItemStack stack) {
+        return (int) (5120 * (1.0 - (0.1 * getUpgradeLevel(stack, FocusUpgradeType.frugal))));
+    }
+
+    @Override
+    public void addInformation(ItemStack stack, EntityPlayer player, List list, boolean par4) {
+        list.add(StatCollector.translateToLocal("item.EMT.focus.EU.cost.info"));
+        list.add(StatCollector.translateToLocalFormatted("item.EMT.focus.EU.cost.once", getCost(stack)));
+        this.addFocusInformation(stack, player, list, par4);
     }
 }

--- a/src/main/java/emt/item/focus/ItemEnergyBallFocus.java
+++ b/src/main/java/emt/item/focus/ItemEnergyBallFocus.java
@@ -45,7 +45,6 @@ public class ItemEnergyBallFocus extends ItemBaseFocus {
             return stack;
         }
 
-        // 10% discount per level of frugal
         int cost = getCost(stack);
         double val = ElectricItem.manager.discharge(armor, cost, 4, true, false, false);
 

--- a/src/main/java/emt/item/focus/ItemEnergyBallFocus.java
+++ b/src/main/java/emt/item/focus/ItemEnergyBallFocus.java
@@ -22,7 +22,7 @@ public class ItemEnergyBallFocus extends ItemBaseFocus {
 
     @Override
     public String getSortingHelper(ItemStack itemstack) {
-        return "ENERGYBALL";
+        return "ENERGYBALL" + super.getSortingHelper(itemstack);
     }
 
     @Override

--- a/src/main/java/emt/item/focus/ItemExplosionFocus.java
+++ b/src/main/java/emt/item/focus/ItemExplosionFocus.java
@@ -39,7 +39,7 @@ public class ItemExplosionFocus extends ItemBaseFocus {
             MovingObjectPosition movingobjectposition) {
         ItemWandCasting wand = (ItemWandCasting) itemstack.getItem();
         if (player.capabilities.isCreativeMode
-                || wand.consumeAllVis(itemstack, player, getVisCost(itemstack), true, true)) {
+                || wand.consumeAllVis(itemstack, player, getVisCost(itemstack), true, false)) {
             if (!world.isRemote) {
                 EntityLaser laser;
                 laser = new EntityLaser(world, player, 1);

--- a/src/main/java/emt/item/focus/ItemExplosionFocus.java
+++ b/src/main/java/emt/item/focus/ItemExplosionFocus.java
@@ -31,7 +31,7 @@ public class ItemExplosionFocus extends ItemBaseFocus {
 
     @Override
     public String getSortingHelper(ItemStack itemstack) {
-        return "EXPLOSION";
+        return "EXPLOSION" + super.getSortingHelper(itemstack);
     }
 
     @Override

--- a/src/main/java/emt/item/focus/ItemExplosionFocus.java
+++ b/src/main/java/emt/item/focus/ItemExplosionFocus.java
@@ -54,12 +54,4 @@ public class ItemExplosionFocus extends ItemBaseFocus {
         return new FocusUpgradeType[] { FocusUpgradeType.potency, FocusUpgradeType.frugal };
     }
 
-    /**
-     * Use this method to define custom logic about which upgrades can be applied. This can be used to set up upgrade
-     * "trees" that make certain upgrades available only when others are unlocked first, when certain research is
-     * completed, or similar logic.
-     */
-    public boolean canApplyUpgrade(ItemStack focusstack, EntityPlayer player, FocusUpgradeType type, int rank) {
-        return true;
-    }
 }

--- a/src/main/java/emt/item/focus/ItemMaintenanceFocus.java
+++ b/src/main/java/emt/item/focus/ItemMaintenanceFocus.java
@@ -60,7 +60,7 @@ public class ItemMaintenanceFocus extends ItemBaseFocus {
                 if (hatchCandidateMetaTile instanceof MTEHatchMaintenance) {
                     MTEHatchMaintenance hatch = (MTEHatchMaintenance) hatchCandidateMetaTile;
                     if (player.capabilities.isCreativeMode
-                            || wand.consumeAllVis(itemStack, player, getVisCost(itemStack), true, true)) {
+                            || wand.consumeAllVis(itemStack, player, getVisCost(itemStack), true, false)) {
                         hatch.mCrowbar = true;
                         hatch.mScrewdriver = true;
                         hatch.mHardHammer = true;

--- a/src/main/java/emt/item/focus/ItemMaintenanceFocus.java
+++ b/src/main/java/emt/item/focus/ItemMaintenanceFocus.java
@@ -35,7 +35,7 @@ public class ItemMaintenanceFocus extends ItemBaseFocus {
 
     @Override
     public String getSortingHelper(ItemStack itemstack) {
-        return "MAINTENANCE";
+        return "MAINTENANCE" + super.getSortingHelper(itemstack);
     }
 
     @Override

--- a/src/main/java/emt/item/focus/ItemShieldFocus.java
+++ b/src/main/java/emt/item/focus/ItemShieldFocus.java
@@ -43,7 +43,7 @@ public class ItemShieldFocus extends ItemBaseFocus {
     }
 
     @Override
-    public boolean isUseItem(ItemStack stack) {
+    public boolean isVisCostPerTick(ItemStack stack) {
         return true;
     }
 

--- a/src/main/java/emt/item/focus/ItemShieldFocus.java
+++ b/src/main/java/emt/item/focus/ItemShieldFocus.java
@@ -1,7 +1,5 @@
 package emt.item.focus;
 
-import java.util.LinkedList;
-
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.potion.PotionEffect;
@@ -12,6 +10,7 @@ import emt.entity.EntityShield;
 import ic2.core.IC2;
 import thaumcraft.api.aspects.Aspect;
 import thaumcraft.api.aspects.AspectList;
+import thaumcraft.api.wands.FocusUpgradeType;
 import thaumcraft.common.items.wands.ItemWandCasting;
 
 public class ItemShieldFocus extends ItemBaseFocus {
@@ -39,6 +38,11 @@ public class ItemShieldFocus extends ItemBaseFocus {
     }
 
     @Override
+    public FocusUpgradeType[] getPossibleUpgradesByRank(ItemStack focusstack, int rank) {
+        return new FocusUpgradeType[] { FocusUpgradeType.frugal };
+    }
+
+    @Override
     public boolean isUseItem(ItemStack stack) {
         return true;
     }
@@ -46,7 +50,7 @@ public class ItemShieldFocus extends ItemBaseFocus {
     @Override
     public void onUsingFocusTick(ItemStack itemstack, EntityPlayer player, int count) {
         ItemWandCasting wand = (ItemWandCasting) itemstack.getItem();
-        for (PotionEffect effect : new LinkedList<PotionEffect>(player.getActivePotionEffects())) {
+        for (PotionEffect effect : player.getActivePotionEffects()) {
             IC2.platform.removePotion(player, effect.getPotionID());
         }
         if (!player.capabilities.isCreativeMode
@@ -61,7 +65,7 @@ public class ItemShieldFocus extends ItemBaseFocus {
         ItemWandCasting wand = (ItemWandCasting) itemstack.getItem();
         player.setItemInUse(itemstack, Integer.MAX_VALUE);
         if (!world.isRemote && (player.capabilities.isCreativeMode
-                || wand.consumeAllVis(itemstack, player, getVisCost(itemstack), true, true))) {
+                || wand.consumeAllVis(itemstack, player, getVisCost(itemstack), true, false))) {
             EntityShield shield = new EntityShield(world, player);
             world.spawnEntityInWorld(shield);
         }

--- a/src/main/java/emt/item/focus/ItemShieldFocus.java
+++ b/src/main/java/emt/item/focus/ItemShieldFocus.java
@@ -35,7 +35,7 @@ public class ItemShieldFocus extends ItemBaseFocus {
 
     @Override
     public String getSortingHelper(ItemStack itemstack) {
-        return "SHIELD";
+        return "SHIELD" + super.getSortingHelper(itemstack);
     }
 
     @Override

--- a/src/main/java/emt/item/focus/ItemShieldFocus.java
+++ b/src/main/java/emt/item/focus/ItemShieldFocus.java
@@ -50,7 +50,7 @@ public class ItemShieldFocus extends ItemBaseFocus {
             IC2.platform.removePotion(player, effect.getPotionID());
         }
         if (!player.capabilities.isCreativeMode
-                && !wand.consumeAllVis(itemstack, player, getVisCost(itemstack), true, true)) {
+                && !wand.consumeAllVis(itemstack, player, getVisCost(itemstack), true, false)) {
             player.stopUsingItem();
         }
     }

--- a/src/main/java/emt/item/focus/ItemWandChargingFocus.java
+++ b/src/main/java/emt/item/focus/ItemWandChargingFocus.java
@@ -28,7 +28,7 @@ public class ItemWandChargingFocus extends ItemBaseFocus {
 
     @Override
     public String getSortingHelper(ItemStack itemstack) {
-        return "ELECTRICCHARGING";
+        return "ELECTRICCHARGING" + super.getSortingHelper(itemstack);
     }
 
     @Override

--- a/src/main/java/emt/item/focus/ItemWandChargingFocus.java
+++ b/src/main/java/emt/item/focus/ItemWandChargingFocus.java
@@ -56,23 +56,37 @@ public class ItemWandChargingFocus extends ItemBaseFocus {
 
         if (!player.worldObj.isRemote) {
             ItemWandCasting wandItem = (ItemWandCasting) itemstack.getItem();
+            if (wandIsFull(itemstack, wandItem)) {
+                return;
+            }
 
-            ItemStack armor = player.inventory.armorInventory[1];
-            if (armor != null) {
-                int cost = getCost(itemstack) / 4;
-                if ((ElectricItem.manager.use(armor, cost, player) && (ElectricItem.manager.use(armor, cost, player))
-                        && (ElectricItem.manager.use(armor, cost, player))
-                        && (ElectricItem.manager.use(armor, cost, player)))) {
-                    int amount = (int) (100 * Math.pow(1.1, getUpgradeLevel(itemstack, FocusUpgradeType.potency)));
-                    wandItem.addRealVis(itemstack, Aspect.ORDER, amount, true);
-                    wandItem.addRealVis(itemstack, Aspect.FIRE, amount, true);
-                    wandItem.addRealVis(itemstack, Aspect.ENTROPY, amount, true);
-                    wandItem.addRealVis(itemstack, Aspect.WATER, amount, true);
-                    wandItem.addRealVis(itemstack, Aspect.EARTH, amount, true);
-                    wandItem.addRealVis(itemstack, Aspect.AIR, amount, true);
+            int cost = getCost(itemstack) / 4;
+            for (ItemStack stack : player.inventory.armorInventory) {
+                if (stack == null || ElectricItem.manager.getCharge(stack) < cost) {
+                    return;
                 }
             }
+            for (ItemStack stack : player.inventory.armorInventory) {
+                ElectricItem.manager.use(stack, cost, player);
+            }
+            int amount = (int) (100 * Math.pow(1.1, getUpgradeLevel(itemstack, FocusUpgradeType.potency)));
+            wandItem.addRealVis(itemstack, Aspect.ORDER, amount, true);
+            wandItem.addRealVis(itemstack, Aspect.FIRE, amount, true);
+            wandItem.addRealVis(itemstack, Aspect.ENTROPY, amount, true);
+            wandItem.addRealVis(itemstack, Aspect.WATER, amount, true);
+            wandItem.addRealVis(itemstack, Aspect.EARTH, amount, true);
+            wandItem.addRealVis(itemstack, Aspect.AIR, amount, true);
         }
+    }
+
+    private boolean wandIsFull(ItemStack itemstack, ItemWandCasting wandItem) {
+        int size = wandItem.getMaxVis(itemstack);
+        for (Aspect a : Aspect.getPrimalAspects()) {
+            if (wandItem.getVis(itemstack, a) < size) {
+                return false;
+            }
+        }
+        return true;
     }
 
     /**

--- a/src/main/java/emt/item/focus/ItemWandChargingFocus.java
+++ b/src/main/java/emt/item/focus/ItemWandChargingFocus.java
@@ -1,9 +1,11 @@
 package emt.item.focus;
 
+import java.util.List;
 import java.util.Map.Entry;
 
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
+import net.minecraft.util.StatCollector;
 
 import emt.util.EMTConfigHandler;
 import ic2.api.item.ElectricItem;
@@ -42,15 +44,11 @@ public class ItemWandChargingFocus extends ItemBaseFocus {
         for (Entry<Aspect, Integer> e : visCost.aspects.entrySet()) actualCost.add(
                 e.getKey(),
                 (int) (e.getValue() * Math.pow(1.1, getUpgradeLevel(stack, FocusUpgradeType.potency))));
-        return visCost;
+        return actualCost;
     }
 
     public FocusUpgradeType[] getPossibleUpgradesByRank(ItemStack focusstack, int rank) {
         return new FocusUpgradeType[] { FocusUpgradeType.potency, FocusUpgradeType.frugal };
-    }
-
-    public boolean canApplyUpgrade(ItemStack focusstack, EntityPlayer player, FocusUpgradeType type, int rank) {
-        return true;
     }
 
     @Override
@@ -61,10 +59,10 @@ public class ItemWandChargingFocus extends ItemBaseFocus {
 
             ItemStack armor = player.inventory.armorInventory[1];
             if (armor != null) {
-                if ((ElectricItem.manager.use(armor, EMTConfigHandler.wandChargeFocusCost / 4, player)
-                        && (ElectricItem.manager.use(armor, EMTConfigHandler.wandChargeFocusCost / 4, player))
-                        && (ElectricItem.manager.use(armor, EMTConfigHandler.wandChargeFocusCost / 4, player))
-                        && (ElectricItem.manager.use(armor, EMTConfigHandler.wandChargeFocusCost / 4, player)))) {
+                int cost = getCost(itemstack) / 4;
+                if ((ElectricItem.manager.use(armor, cost, player) && (ElectricItem.manager.use(armor, cost, player))
+                        && (ElectricItem.manager.use(armor, cost, player))
+                        && (ElectricItem.manager.use(armor, cost, player)))) {
                     int amount = (int) (100 * Math.pow(1.1, getUpgradeLevel(itemstack, FocusUpgradeType.potency)));
                     wandItem.addRealVis(itemstack, Aspect.ORDER, amount, true);
                     wandItem.addRealVis(itemstack, Aspect.FIRE, amount, true);
@@ -75,5 +73,20 @@ public class ItemWandChargingFocus extends ItemBaseFocus {
                 }
             }
         }
+    }
+
+    /**
+     * Base cost from config with a 10% discount per level of frugal.
+     */
+    private int getCost(ItemStack stack) {
+        return (int) (EMTConfigHandler.wandChargeFocusCost
+                * (1.0 - (0.1 * getUpgradeLevel(stack, FocusUpgradeType.frugal))));
+    }
+
+    @Override
+    public void addInformation(ItemStack stack, EntityPlayer player, List list, boolean par4) {
+        list.add(StatCollector.translateToLocal("item.EMT.focus.EU.cost.info"));
+        list.add(StatCollector.translateToLocalFormatted("item.EMT.focus.EU.cost.tick", getCost(stack)));
+        super.addInformation(stack, player, list, par4);
     }
 }

--- a/src/main/resources/assets/emt/lang/de_DE.lang
+++ b/src/main/resources/assets/emt/lang/de_DE.lang
@@ -13,9 +13,9 @@ gui.EMT.book.aspect.output.eu.title=Essentia Ausgabe Buch
 gui.EMT.book.aspect.output.essentia.eu=EU Leistung per Essentia
 gui.EMT.key.unequip=Ausziehen
 emt.Output=Ausgabe:
-emt.Storage=Speicher: 
+emt.Storage=Speicher:
 emt.PressShift=<Drücke SHIFT>
-emt.Generating=Erzeugt: 
+emt.Generating=Erzeugt:
 emt.Fuel=Brennstoff
 
 #=============Tooltips=============
@@ -100,6 +100,9 @@ item.EMT.focus.charge.name=Stab Fokus: Aufladung
 item.EMT.focus.chargeWand.name=Stab Fokus: Stabs Aufladung
 item.EMT.focus.electricCloud.name=Electrische Wolke
 item.EMT.focus.energyBall.name=Energie Ball Fokus
+item.EMT.focus.EU.cost.info=EU pro Zauber
+item.EMT.focus.EU.cost.once= %s §eEU§0
+item.EMT.focus.EU.cost.tick= %s §eEU/t§0
 
 #=============Block Names=============
 tile.EMT.electricCloud.name=Electrische Wolke

--- a/src/main/resources/assets/emt/lang/de_DE.lang
+++ b/src/main/resources/assets/emt/lang/de_DE.lang
@@ -101,8 +101,8 @@ item.EMT.focus.chargeWand.name=Stab Fokus: Stabs Aufladung
 item.EMT.focus.electricCloud.name=Electrische Wolke
 item.EMT.focus.energyBall.name=Energie Ball Fokus
 item.EMT.focus.EU.cost.info=EU pro Zauber
-item.EMT.focus.EU.cost.once= %s §eEU§0
-item.EMT.focus.EU.cost.tick= %s §eEU/t§0
+item.EMT.focus.EU.cost.once= §r%s §eEU§0
+item.EMT.focus.EU.cost.tick= §r%s §eEU/t§0
 
 #=============Block Names=============
 tile.EMT.electricCloud.name=Electrische Wolke

--- a/src/main/resources/assets/emt/lang/en_US.lang
+++ b/src/main/resources/assets/emt/lang/en_US.lang
@@ -110,8 +110,8 @@ item.EMT.focus.maintenance.name=Wand Focus: Maintenance
 item.EMT.focus.electricCloud.name=Electric Cloud
 item.EMT.focus.energyBall.name=Energy Ball Focus
 item.EMT.focus.EU.cost.info=EU per cast
-item.EMT.focus.EU.cost.once= %s §eEU§0
-item.EMT.focus.EU.cost.tick= %s §eEU/t§0
+item.EMT.focus.EU.cost.once= §r%s §eEU§0
+item.EMT.focus.EU.cost.tick= §r%s §eEU/t§0
 
 #=============Block Names=============
 tile.EMT.electricCloud.name=Electric Cloud

--- a/src/main/resources/assets/emt/lang/en_US.lang
+++ b/src/main/resources/assets/emt/lang/en_US.lang
@@ -109,6 +109,9 @@ item.EMT.focus.chargeWand.name=Wand Focus: Wand Charging
 item.EMT.focus.maintenance.name=Wand Focus: Maintenance
 item.EMT.focus.electricCloud.name=Electric Cloud
 item.EMT.focus.energyBall.name=Energy Ball Focus
+item.EMT.focus.EU.cost.info=EU per cast
+item.EMT.focus.EU.cost.once= %s §eEU§0
+item.EMT.focus.EU.cost.tick= %s §eEU/t§0
 
 #=============Block Names=============
 tile.EMT.electricCloud.name=Electric Cloud

--- a/src/main/resources/assets/emt/lang/ru_RU.lang
+++ b/src/main/resources/assets/emt/lang/ru_RU.lang
@@ -103,8 +103,8 @@ item.EMT.focus.maintenance.name=Набалдашник: Обслуживание
 item.EMT.focus.electricCloud.name=Электризованное облако
 item.EMT.focus.energyBall.name=Набалдашник: Наэлектризованное облако
 item.EMT.focus.EU.cost.info=EU за использование
-item.EMT.focus.EU.cost.once= %s §eEU§0
-item.EMT.focus.EU.cost.tick= %s §eEU/тик§0
+item.EMT.focus.EU.cost.once= §r%s §eEU§0
+item.EMT.focus.EU.cost.tick= §r%s §eEU/тик§0
 
 #=============Block Names=============
 tile.EMT.electricCloud.name=Наэлектризованное облако

--- a/src/main/resources/assets/emt/lang/ru_RU.lang
+++ b/src/main/resources/assets/emt/lang/ru_RU.lang
@@ -102,6 +102,9 @@ item.EMT.focus.chargeWand.name=Набалдашник: Зарядка жезла
 item.EMT.focus.maintenance.name=Набалдашник: Обслуживание
 item.EMT.focus.electricCloud.name=Электризованное облако
 item.EMT.focus.energyBall.name=Набалдашник: Наэлектризованное облако
+item.EMT.focus.EU.cost.info=EU за использование
+item.EMT.focus.EU.cost.once= %s §eEU§0
+item.EMT.focus.EU.cost.tick= %s §eEU/тик§0
 
 #=============Block Names=============
 tile.EMT.electricCloud.name=Наэлектризованное облако

--- a/src/main/resources/assets/emt/lang/zh_CN.lang
+++ b/src/main/resources/assets/emt/lang/zh_CN.lang
@@ -103,8 +103,8 @@ item.EMT.focus.chargeWand.name=法杖核心:化魔
 item.EMT.focus.electricCloud.name=雷云之光
 item.EMT.focus.energyBall.name=法杖核心:能量球
 item.EMT.focus.EU.cost.info=EU/每次施法
-item.EMT.focus.EU.cost.once= %s §eEU§0
-item.EMT.focus.EU.cost.tick= %s §eEU/t§0
+item.EMT.focus.EU.cost.once= §r%s §eEU§0
+item.EMT.focus.EU.cost.tick= §r%s §eEU/t§0
 
 #=============Block Names=============
 tile.EMT.electricCloud.name=雷云之光

--- a/src/main/resources/assets/emt/lang/zh_CN.lang
+++ b/src/main/resources/assets/emt/lang/zh_CN.lang
@@ -102,6 +102,9 @@ item.EMT.focus.charge.name=法杖核心:充电
 item.EMT.focus.chargeWand.name=法杖核心:化魔
 item.EMT.focus.electricCloud.name=雷云之光
 item.EMT.focus.energyBall.name=法杖核心:能量球
+item.EMT.focus.EU.cost.info=EU/每次施法
+item.EMT.focus.EU.cost.once= %s §eEU§0
+item.EMT.focus.EU.cost.tick= %s §eEU/t§0
 
 #=============Block Names=============
 tile.EMT.electricCloud.name=雷云之光


### PR DESCRIPTION
Fix a few bugs/odd behaviors:
Set the "crafting" parameter in wand.consumeAllVis() to false to allow for frugal to actually work for all of the foci. That is supposed to be true for arcane workbench crafts and forming multiblocks and false for focus actions.
Remove enchantability from the base focus class.
Fix getVisCost methods for the (wand) charge focus so that potency actually works for them.
Wand charge focus now draws EU from all armor slots evenly instead of only the legs slot (now matches Thaumonomicon entry). It only draws power when the wand is not full and all armor slots have charge to prevent waste.
Fix getSortingHelper so that foci of the same type with different upgrades can be selected in the focus menu.

Improvements:
Add the ability to choose the frugal upgrade to a bunch of foci. Frugal reduces EU costs by 10% per level for the foci that take power instead of vis.
Improve tooltips for foci that deal with EU. Energy Ball Focus as an example:
![image](https://github.com/user-attachments/assets/dc0afabd-f808-441e-9b86-7f61366a9171)
Updates with frugal:
![image](https://github.com/user-attachments/assets/dd4705e9-c247-49d1-a5c4-b4faf36d1a0e)
I did my best to translate those tooltips based on the base Thaum "Vis per cast", but feel free to ask me to change them if I got something wrong.

Cleanup:
Remove a bunch of methods that are the same as the ones in the base classes.