### PR TITLE
Fix solar panel draining Thaumcraft node twice

### DIFF
--- a/src/main/java/emt/tile/solar/TileEntitySolarBase.java
+++ b/src/main/java/emt/tile/solar/TileEntitySolarBase.java
@@ -162,8 +162,7 @@ public class TileEntitySolarBase extends TileEntityEMT implements IInventory, IW
             case AQUA: {
                 if (worldObj.isThundering()) return 6F;
                 else if (worldObj.isRaining()) return 3F;
-                else if (!worldObj.isThundering() && !worldObj.isRaining()
-                        && worldObj.getBlock(xCoord, yCoord + 1, zCoord).equals(Blocks.water))
+                else if (worldObj.getBlock(xCoord, yCoord + 1, zCoord).equals(Blocks.water))
                     return 2F;
                 else return 1F;
             }

--- a/src/main/java/emt/tile/solar/TileEntitySolarBase.java
+++ b/src/main/java/emt/tile/solar/TileEntitySolarBase.java
@@ -193,7 +193,7 @@ public class TileEntitySolarBase extends TileEntityEMT implements IInventory, IW
                     this.isActive = true;
                     if (side) {
                         this.generating = output * calc_multi();
-                        this.energySource.addEnergy(this.output * calc_multi());
+                        this.energySource.addEnergy(this.generating);
                     }
                 } else {
                     isActive = false;

--- a/src/main/java/emt/tile/solar/TileEntitySolarBase.java
+++ b/src/main/java/emt/tile/solar/TileEntitySolarBase.java
@@ -162,8 +162,7 @@ public class TileEntitySolarBase extends TileEntityEMT implements IInventory, IW
             case AQUA: {
                 if (worldObj.isThundering()) return 6F;
                 else if (worldObj.isRaining()) return 3F;
-                else if (worldObj.getBlock(xCoord, yCoord + 1, zCoord).equals(Blocks.water))
-                    return 2F;
+                else if (worldObj.getBlock(xCoord, yCoord + 1, zCoord).equals(Blocks.water)) return 2F;
                 else return 1F;
             }
             case IGNIS: {


### PR DESCRIPTION
The bug existed since 2018. 

Fire Infused Solar Panels use the function calc_multi() to calculate multiplier. It does the same twice, the first call is to save it inside and draw in GUI. The second call is to add energy to real buffer. The problem is that calc_multi() drains vis every call. That's why it may say it generates 6k EU/t in GUI, but in reality it will generate much less, since all the vis is already drained during the first call.

<img width="980" height="649" alt="image" src="https://github.com/user-attachments/assets/5a3433f1-0eb5-47a1-a30d-2cd19d9d94c5" />
<img width="758" height="504" alt="image" src="https://github.com/user-attachments/assets/0b528fa6-87f7-4ab8-aa82-0309e4427b60" />
<img width="702" height="573" alt="image" src="https://github.com/user-attachments/assets/7fdd1e14-50f2-42c3-b685-c2dc38c8af8f" />
