### PR TITLE
Swap references to EMT.TEXTURE_PATH with EMT.RESOURCE_PATH

### DIFF
--- a/src/main/java/emt/EMT.java
+++ b/src/main/java/emt/EMT.java
@@ -42,7 +42,6 @@ public class EMT {
     public static final String MOD_ID = "EMT";
     public static final String VERSION = EMTTags.VERSION;
     public static final String RESOURCE_PATH = "emt";
-    public static final String TEXTURE_PATH = RESOURCE_PATH;
     public static final String GUI_FACTORY = "emt.client.gui.config.EMTGuiFactory";
     public static final String CLIENT_PROXY = "emt.proxy.ClientProxy";
     public static final String COMMON_PROXY = "emt.proxy.CommonProxy";

--- a/src/main/java/emt/block/BlockBase.java
+++ b/src/main/java/emt/block/BlockBase.java
@@ -14,7 +14,7 @@ public abstract class BlockBase extends Block {
         name = unlocName;
         setBlockName(EMT.MOD_ID + ".block." + unlocName);
         if (textureName != null) {
-            setBlockTextureName(EMT.TEXTURE_PATH + ":" + textureName);
+            setBlockTextureName(EMT.RESOURCE_PATH + ":" + textureName);
         }
         setCreativeTab(EMT.TAB);
         setStepSound(soundType);

--- a/src/main/java/emt/block/BlockElectricCloud.java
+++ b/src/main/java/emt/block/BlockElectricCloud.java
@@ -56,7 +56,7 @@ public class BlockElectricCloud extends BlockBase {
 
     @Override
     public void registerBlockIcons(IIconRegister ir) {
-        icon = ir.registerIcon(EMT.TEXTURE_PATH + ":empty");
+        icon = ir.registerIcon(EMT.RESOURCE_PATH + ":empty");
     }
 
     @Override

--- a/src/main/java/emt/block/BlockEssentiaGenerators.java
+++ b/src/main/java/emt/block/BlockEssentiaGenerators.java
@@ -33,20 +33,20 @@ public class BlockEssentiaGenerators extends BlockBaseContainer {
     @SideOnly(Side.CLIENT)
     public void registerBlockIcons(IIconRegister ir) {
         super.registerBlockIcons(ir);
-        this.blockIcon = ir.registerIcon(EMT.TEXTURE_PATH + ":machines/top");
+        this.blockIcon = ir.registerIcon(EMT.RESOURCE_PATH + ":machines/top");
 
         for (int meta = 0; meta < subtypes; meta++) {
-            iconSets[meta].top = ir.registerIcon(EMT.TEXTURE_PATH + ":essentiagenerator/top");
-            iconSets[meta].bottom = ir.registerIcon(EMT.TEXTURE_PATH + ":essentiagenerator/top");
-            iconSets[meta].side = ir.registerIcon(EMT.TEXTURE_PATH + ":essentiagenerator/side");
+            iconSets[meta].top = ir.registerIcon(EMT.RESOURCE_PATH + ":essentiagenerator/top");
+            iconSets[meta].bottom = ir.registerIcon(EMT.RESOURCE_PATH + ":essentiagenerator/top");
+            iconSets[meta].side = ir.registerIcon(EMT.RESOURCE_PATH + ":essentiagenerator/side");
         }
 
-        iconSets[0].frontOff = ir.registerIcon(EMT.TEXTURE_PATH + ":essentiagenerator/potentiafront");
-        iconSets[1].frontOff = ir.registerIcon(EMT.TEXTURE_PATH + ":essentiagenerator/ignisfront");
-        iconSets[2].frontOff = ir.registerIcon(EMT.TEXTURE_PATH + ":essentiagenerator/auramfront");
-        iconSets[3].frontOff = ir.registerIcon(EMT.TEXTURE_PATH + ":essentiagenerator/arborfront");
-        iconSets[4].frontOff = ir.registerIcon(EMT.TEXTURE_PATH + ":essentiagenerator/aerfront");
-        iconSets[5].frontOff = ir.registerIcon(EMT.TEXTURE_PATH + ":essentiagenerator/aerfront");
+        iconSets[0].frontOff = ir.registerIcon(EMT.RESOURCE_PATH + ":essentiagenerator/potentiafront");
+        iconSets[1].frontOff = ir.registerIcon(EMT.RESOURCE_PATH + ":essentiagenerator/ignisfront");
+        iconSets[2].frontOff = ir.registerIcon(EMT.RESOURCE_PATH + ":essentiagenerator/auramfront");
+        iconSets[3].frontOff = ir.registerIcon(EMT.RESOURCE_PATH + ":essentiagenerator/arborfront");
+        iconSets[4].frontOff = ir.registerIcon(EMT.RESOURCE_PATH + ":essentiagenerator/aerfront");
+        iconSets[5].frontOff = ir.registerIcon(EMT.RESOURCE_PATH + ":essentiagenerator/aerfront");
     }
 
     @Override

--- a/src/main/java/emt/block/BlockMachines.java
+++ b/src/main/java/emt/block/BlockMachines.java
@@ -36,27 +36,27 @@ public class BlockMachines extends BlockBaseContainer {
     public void registerBlockIcons(IIconRegister ir) {
         super.registerBlockIcons(ir);
 
-        this.blockIcon = ir.registerIcon(EMT.TEXTURE_PATH + ":machines/top");
+        this.blockIcon = ir.registerIcon(EMT.RESOURCE_PATH + ":machines/top");
 
-        iconSets[0].top = ir.registerIcon(EMT.TEXTURE_PATH + ":machines/top");
-        iconSets[1].top = ir.registerIcon(EMT.TEXTURE_PATH + ":machines/etherealmaceratortop");
-        iconSets[2].top = ir.registerIcon(EMT.TEXTURE_PATH + ":machines/etherealmaceratortop");
+        iconSets[0].top = ir.registerIcon(EMT.RESOURCE_PATH + ":machines/top");
+        iconSets[1].top = ir.registerIcon(EMT.RESOURCE_PATH + ":machines/etherealmaceratortop");
+        iconSets[2].top = ir.registerIcon(EMT.RESOURCE_PATH + ":machines/etherealmaceratortop");
 
-        iconSets[0].bottom = ir.registerIcon(EMT.TEXTURE_PATH + ":machines/side");
-        iconSets[1].bottom = ir.registerIcon(EMT.TEXTURE_PATH + ":machines/etherealmacerator");
-        iconSets[2].bottom = ir.registerIcon(EMT.TEXTURE_PATH + ":machines/etherealmaceratortop");
+        iconSets[0].bottom = ir.registerIcon(EMT.RESOURCE_PATH + ":machines/side");
+        iconSets[1].bottom = ir.registerIcon(EMT.RESOURCE_PATH + ":machines/etherealmacerator");
+        iconSets[2].bottom = ir.registerIcon(EMT.RESOURCE_PATH + ":machines/etherealmaceratortop");
 
-        iconSets[0].side = ir.registerIcon(EMT.TEXTURE_PATH + ":machines/side");
-        iconSets[1].side = ir.registerIcon(EMT.TEXTURE_PATH + ":machines/etherealmacerator");
-        iconSets[2].side = ir.registerIcon(EMT.TEXTURE_PATH + ":machines/etherealmaceratortop");
+        iconSets[0].side = ir.registerIcon(EMT.RESOURCE_PATH + ":machines/side");
+        iconSets[1].side = ir.registerIcon(EMT.RESOURCE_PATH + ":machines/etherealmacerator");
+        iconSets[2].side = ir.registerIcon(EMT.RESOURCE_PATH + ":machines/etherealmaceratortop");
 
-        iconSets[0].frontOff = ir.registerIcon(EMT.TEXTURE_PATH + ":machines/wandcharger");
-        iconSets[1].frontOff = ir.registerIcon(EMT.TEXTURE_PATH + ":machines/etherealmaceratorfront");
-        iconSets[2].frontOff = ir.registerIcon(EMT.TEXTURE_PATH + ":machines/etherealmaceratortop");
+        iconSets[0].frontOff = ir.registerIcon(EMT.RESOURCE_PATH + ":machines/wandcharger");
+        iconSets[1].frontOff = ir.registerIcon(EMT.RESOURCE_PATH + ":machines/etherealmaceratorfront");
+        iconSets[2].frontOff = ir.registerIcon(EMT.RESOURCE_PATH + ":machines/etherealmaceratortop");
 
-        iconSets[0].frontOn = ir.registerIcon(EMT.TEXTURE_PATH + ":machines/wandcharger");
-        iconSets[1].frontOn = ir.registerIcon(EMT.TEXTURE_PATH + ":machines/etherealmaceratorfrontactive");
-        iconSets[2].frontOn = ir.registerIcon(EMT.TEXTURE_PATH + ":machines/etherealmaceratortop");
+        iconSets[0].frontOn = ir.registerIcon(EMT.RESOURCE_PATH + ":machines/wandcharger");
+        iconSets[1].frontOn = ir.registerIcon(EMT.RESOURCE_PATH + ":machines/etherealmaceratorfrontactive");
+        iconSets[2].frontOn = ir.registerIcon(EMT.RESOURCE_PATH + ":machines/etherealmaceratortop");
     }
 
     @SideOnly(Side.CLIENT)

--- a/src/main/java/emt/block/BlockPortableNode.java
+++ b/src/main/java/emt/block/BlockPortableNode.java
@@ -60,7 +60,7 @@ public class BlockPortableNode extends BlockAiry {
     @SideOnly(Side.CLIENT)
     @Override
     public void registerBlockIcons(IIconRegister ri) {
-        texture = ri.registerIcon(EMT.TEXTURE_PATH + ":portablenode");
+        texture = ri.registerIcon(EMT.RESOURCE_PATH + ":portablenode");
     }
 
     @SideOnly(Side.CLIENT)

--- a/src/main/java/emt/block/BlockShield.java
+++ b/src/main/java/emt/block/BlockShield.java
@@ -39,7 +39,7 @@ public class BlockShield extends Block {
     @SideOnly(Side.CLIENT)
     @Override
     public void registerBlockIcons(IIconRegister iconRegister) {
-        this.blockIcon = iconRegister.registerIcon(EMT.TEXTURE_PATH + ":shield");
+        this.blockIcon = iconRegister.registerIcon(EMT.RESOURCE_PATH + ":shield");
     }
 
     @Override

--- a/src/main/java/emt/block/BlockSolars.java
+++ b/src/main/java/emt/block/BlockSolars.java
@@ -30,19 +30,19 @@ public class BlockSolars extends BlockBaseContainer {
     @Override
     @SideOnly(Side.CLIENT)
     public void registerBlockIcons(IIconRegister ir) {
-        IIcon solarTop = ir.registerIcon(EMT.TEXTURE_PATH + ":solars/solartop");
-        IIcon doubleSolarTop = ir.registerIcon(EMT.TEXTURE_PATH + ":solars/doublesolartop");
-        IIcon tripleSolarTop = ir.registerIcon(EMT.TEXTURE_PATH + ":solars/triplesolartop");
+        IIcon solarTop = ir.registerIcon(EMT.RESOURCE_PATH + ":solars/solartop");
+        IIcon doubleSolarTop = ir.registerIcon(EMT.RESOURCE_PATH + ":solars/doublesolartop");
+        IIcon tripleSolarTop = ir.registerIcon(EMT.RESOURCE_PATH + ":solars/triplesolartop");
 
-        IIcon bottom = ir.registerIcon(EMT.TEXTURE_PATH + ":solars/bottom");
+        IIcon bottom = ir.registerIcon(EMT.RESOURCE_PATH + ":solars/bottom");
 
-        IIcon side = ir.registerIcon(EMT.TEXTURE_PATH + ":solars/side");
-        IIcon waterSide = ir.registerIcon(EMT.TEXTURE_PATH + ":solars/water/waterside");
-        IIcon darkSide = ir.registerIcon(EMT.TEXTURE_PATH + ":solars/dark/darkside");
-        IIcon orderSide = ir.registerIcon(EMT.TEXTURE_PATH + ":solars/order/orderside");
-        IIcon fireSide = ir.registerIcon(EMT.TEXTURE_PATH + ":solars/fire/fireside");
-        IIcon airSide = ir.registerIcon(EMT.TEXTURE_PATH + ":solars/air/airside");
-        IIcon earthSide = ir.registerIcon(EMT.TEXTURE_PATH + ":solars/earth/earthside");
+        IIcon side = ir.registerIcon(EMT.RESOURCE_PATH + ":solars/side");
+        IIcon waterSide = ir.registerIcon(EMT.RESOURCE_PATH + ":solars/water/waterside");
+        IIcon darkSide = ir.registerIcon(EMT.RESOURCE_PATH + ":solars/dark/darkside");
+        IIcon orderSide = ir.registerIcon(EMT.RESOURCE_PATH + ":solars/order/orderside");
+        IIcon fireSide = ir.registerIcon(EMT.RESOURCE_PATH + ":solars/fire/fireside");
+        IIcon airSide = ir.registerIcon(EMT.RESOURCE_PATH + ":solars/air/airside");
+        IIcon earthSide = ir.registerIcon(EMT.RESOURCE_PATH + ":solars/earth/earthside");
 
         IIcon[] sides = { side, orderSide, darkSide, airSide, earthSide, waterSide, fireSide };
 

--- a/src/main/java/emt/client/gui/EMT_UITextures.java
+++ b/src/main/java/emt/client/gui/EMT_UITextures.java
@@ -1,22 +1,22 @@
 package emt.client.gui;
 
-import static emt.EMT.TEXTURE_PATH;
+import static emt.EMT.RESOURCE_PATH;
 
 import com.gtnewhorizons.modularui.api.drawable.UITexture;
 
 public class EMT_UITextures {
 
     public static final UITexture OVERLAY_SLOT_FUSION_CRAFTING = UITexture
-            .fullImage(TEXTURE_PATH, "guis/overlay_slot/fusion_crafter");
-    public static final UITexture OVERLAY_SLOT_WAND = UITexture.fullImage(TEXTURE_PATH, "guis/overlay_slot/wand");
+            .fullImage(RESOURCE_PATH, "guis/overlay_slot/fusion_crafter");
+    public static final UITexture OVERLAY_SLOT_WAND = UITexture.fullImage(RESOURCE_PATH, "guis/overlay_slot/wand");
 
     public static final UITexture PICTURE_GAUGE_EMPTY_25 = UITexture
-            .fullImage(TEXTURE_PATH, "guis/picture/gauge_empty_25");
+            .fullImage(RESOURCE_PATH, "guis/picture/gauge_empty_25");
     public static final UITexture PICTURE_GAUGE_GENERATOR = UITexture
-            .fullImage(TEXTURE_PATH, "guis/picture/gauge_generator");
-    public static final UITexture PICTURE_GAUGE_SOLAR = UITexture.fullImage(TEXTURE_PATH, "guis/picture/gauge_solar");
+            .fullImage(RESOURCE_PATH, "guis/picture/gauge_generator");
+    public static final UITexture PICTURE_GAUGE_SOLAR = UITexture.fullImage(RESOURCE_PATH, "guis/picture/gauge_solar");
     public static final UITexture PICTURE_GAUGE_EMPTY_11 = UITexture
-            .fullImage(TEXTURE_PATH, "guis/picture/gauge_empty_11");
+            .fullImage(RESOURCE_PATH, "guis/picture/gauge_empty_11");
     public static final UITexture PICTURE_SOLAR_INDICATOR = UITexture
-            .fullImage(TEXTURE_PATH, "guis/picture/solar_indicator");
+            .fullImage(RESOURCE_PATH, "guis/picture/solar_indicator");
 }

--- a/src/main/java/emt/client/renderer/RenderLaser.java
+++ b/src/main/java/emt/client/renderer/RenderLaser.java
@@ -14,7 +14,7 @@ import emt.entity.EntityLaser;
 public class RenderLaser extends Render {
 
     private static final ResourceLocation laserTexture = new ResourceLocation(
-            EMT.TEXTURE_PATH,
+            EMT.RESOURCE_PATH,
             "textures/models/lasermodel.png");
 
     @Override

--- a/src/main/java/emt/client/renderer/RenderShield.java
+++ b/src/main/java/emt/client/renderer/RenderShield.java
@@ -19,7 +19,7 @@ import emt.entity.EntityShield;
 public class RenderShield extends Render {
 
     private static final ResourceLocation shieldTexture = new ResourceLocation(
-            EMT.TEXTURE_PATH,
+            EMT.RESOURCE_PATH,
             "textures/models/shield.png");
     static int glCallList;
 

--- a/src/main/java/emt/init/EMTResearches.java
+++ b/src/main/java/emt/init/EMTResearches.java
@@ -19,9 +19,9 @@ public class EMTResearches {
     }
 
     public static void addResearchTab() {
-        ResourceLocation background = new ResourceLocation(EMT.TEXTURE_PATH, "textures/misc/background.png");
+        ResourceLocation background = new ResourceLocation(EMT.RESOURCE_PATH, "textures/misc/background.png");
         ResearchCategories
-                .registerCategory("EMT", new ResourceLocation(EMT.TEXTURE_PATH, "textures/misc/emt.png"), background);
+                .registerCategory("EMT", new ResourceLocation(EMT.RESOURCE_PATH, "textures/misc/emt.png"), background);
     }
 
     public static void addResearch() {
@@ -31,7 +31,7 @@ public class EMTResearches {
                 0,
                 0,
                 0,
-                new ResourceLocation(EMT.TEXTURE_PATH, "textures/misc/emt.png")).setRound().setAutoUnlock()
+                new ResourceLocation(EMT.RESOURCE_PATH, "textures/misc/emt.png")).setRound().setAutoUnlock()
                         .registerResearchItem().setPages(new ResearchPage(""));
         new EMTResearchItem("Diamond Chainsaw", 5, -6, 0, new ItemStack(EMTItems.diamondChainsaw)).setRound()
                 .setAutoUnlock().registerResearchItem()

--- a/src/main/java/emt/item/ItemBase.java
+++ b/src/main/java/emt/item/ItemBase.java
@@ -12,7 +12,7 @@ public class ItemBase extends Item {
     public ItemBase(String unlocName, String textureName) {
         super();
         setUnlocalizedName(EMT.MOD_ID + unlocName);
-        setTextureName(EMT.TEXTURE_PATH + ":" + textureName);
+        setTextureName(EMT.RESOURCE_PATH + ":" + textureName);
         setCreativeTab(EMT.TAB);
     }
 

--- a/src/main/java/emt/item/ItemIC2Baubles.java
+++ b/src/main/java/emt/item/ItemIC2Baubles.java
@@ -57,8 +57,8 @@ public class ItemIC2Baubles extends ItemBase implements IBauble, IRunicArmor {
 
     @SideOnly(Side.CLIENT)
     public void registerIcons(IIconRegister ri) {
-        this.icon[0] = ri.registerIcon(EMT.TEXTURE_PATH + ":armoreumaker");
-        this.icon[1] = ri.registerIcon(EMT.TEXTURE_PATH + ":inventoryeumaker");
+        this.icon[0] = ri.registerIcon(EMT.RESOURCE_PATH + ":armoreumaker");
+        this.icon[1] = ri.registerIcon(EMT.RESOURCE_PATH + ":inventoryeumaker");
     }
 
     @SideOnly(Side.CLIENT)

--- a/src/main/java/emt/item/ItemMaterials.java
+++ b/src/main/java/emt/item/ItemMaterials.java
@@ -124,26 +124,26 @@ public class ItemMaterials extends Item {
 
     @SideOnly(Side.CLIENT)
     public void registerIcons(IIconRegister ri) {
-        this.icon[0] = ri.registerIcon(EMT.TEXTURE_PATH + ":materials/clusteruranium");
-        this.icon[1] = ri.registerIcon(EMT.TEXTURE_PATH + ":materials/crushedamber");
-        this.icon[2] = ri.registerIcon(EMT.TEXTURE_PATH + ":materials/purifiedamber");
-        this.icon[3] = ri.registerIcon(EMT.TEXTURE_PATH + ":materials/crushedcinnabar");
-        this.icon[4] = ri.registerIcon(EMT.TEXTURE_PATH + ":materials/purifiedcinnabar");
-        this.icon[5] = ri.registerIcon(EMT.TEXTURE_PATH + ":materials/thaumiumplate");
-        this.icon[6] = ri.registerIcon(EMT.TEXTURE_PATH + ":materials/lightningsummoner");
-        this.icon[7] = ri.registerIcon(EMT.TEXTURE_PATH + ":materials/feathermesh");
-        this.icon[8] = ri.registerIcon(EMT.TEXTURE_PATH + ":materials/glue");
-        this.icon[9] = ri.registerIcon(EMT.TEXTURE_PATH + ":materials/ducttape");
-        this.icon[10] = ri.registerIcon(EMT.TEXTURE_PATH + ":materials/rubberball");
-        this.icon[11] = ri.registerIcon(EMT.TEXTURE_PATH + ":materials/cardboard");
-        this.icon[12] = ri.registerIcon(EMT.TEXTURE_PATH + ":materials/cardboardsheet");
-        this.icon[13] = ri.registerIcon(EMT.TEXTURE_PATH + ":materials/taintedfeather");
-        this.icon[14] = ri.registerIcon(EMT.TEXTURE_PATH + ":materials/thaumiumWing");
-        this.icon[15] = ri.registerIcon(EMT.TEXTURE_PATH + ":materials/uumatterdrop");
-        this.icon[16] = ri.registerIcon(EMT.TEXTURE_PATH + ":materials/draconicSchematic");
-        this.icon[17] = ri.registerIcon(EMT.TEXTURE_PATH + ":materials/wyvernSchematic");
-        this.icon[18] = ri.registerIcon(EMT.TEXTURE_PATH + ":materials/awakenedSchematic");
-        this.icon[19] = ri.registerIcon(EMT.TEXTURE_PATH + ":materials/chaoticSchematic");
+        this.icon[0] = ri.registerIcon(EMT.RESOURCE_PATH + ":materials/clusteruranium");
+        this.icon[1] = ri.registerIcon(EMT.RESOURCE_PATH + ":materials/crushedamber");
+        this.icon[2] = ri.registerIcon(EMT.RESOURCE_PATH + ":materials/purifiedamber");
+        this.icon[3] = ri.registerIcon(EMT.RESOURCE_PATH + ":materials/crushedcinnabar");
+        this.icon[4] = ri.registerIcon(EMT.RESOURCE_PATH + ":materials/purifiedcinnabar");
+        this.icon[5] = ri.registerIcon(EMT.RESOURCE_PATH + ":materials/thaumiumplate");
+        this.icon[6] = ri.registerIcon(EMT.RESOURCE_PATH + ":materials/lightningsummoner");
+        this.icon[7] = ri.registerIcon(EMT.RESOURCE_PATH + ":materials/feathermesh");
+        this.icon[8] = ri.registerIcon(EMT.RESOURCE_PATH + ":materials/glue");
+        this.icon[9] = ri.registerIcon(EMT.RESOURCE_PATH + ":materials/ducttape");
+        this.icon[10] = ri.registerIcon(EMT.RESOURCE_PATH + ":materials/rubberball");
+        this.icon[11] = ri.registerIcon(EMT.RESOURCE_PATH + ":materials/cardboard");
+        this.icon[12] = ri.registerIcon(EMT.RESOURCE_PATH + ":materials/cardboardsheet");
+        this.icon[13] = ri.registerIcon(EMT.RESOURCE_PATH + ":materials/taintedfeather");
+        this.icon[14] = ri.registerIcon(EMT.RESOURCE_PATH + ":materials/thaumiumWing");
+        this.icon[15] = ri.registerIcon(EMT.RESOURCE_PATH + ":materials/uumatterdrop");
+        this.icon[16] = ri.registerIcon(EMT.RESOURCE_PATH + ":materials/draconicSchematic");
+        this.icon[17] = ri.registerIcon(EMT.RESOURCE_PATH + ":materials/wyvernSchematic");
+        this.icon[18] = ri.registerIcon(EMT.RESOURCE_PATH + ":materials/awakenedSchematic");
+        this.icon[19] = ri.registerIcon(EMT.RESOURCE_PATH + ":materials/chaoticSchematic");
     }
 
     @SideOnly(Side.CLIENT)

--- a/src/main/java/emt/item/ItemOneRing.java
+++ b/src/main/java/emt/item/ItemOneRing.java
@@ -72,7 +72,7 @@ public class ItemOneRing extends ItemBase implements IBauble, IWarpingGear, IRun
 
     @SideOnly(Side.CLIENT)
     public void registerIcons(IIconRegister ri) {
-        this.icon[0] = ri.registerIcon(EMT.TEXTURE_PATH + ":onering");
+        this.icon[0] = ri.registerIcon(EMT.RESOURCE_PATH + ":onering");
     }
 
     @SideOnly(Side.CLIENT)

--- a/src/main/java/emt/item/armor/boots/ItemElectricBootsTraveller.java
+++ b/src/main/java/emt/item/armor/boots/ItemElectricBootsTraveller.java
@@ -73,7 +73,7 @@ public class ItemElectricBootsTraveller extends ItemArmor
     @SideOnly(Side.CLIENT)
     @Override
     public void registerIcons(IIconRegister iconRegister) {
-        this.itemIcon = iconRegister.registerIcon(EMT.TEXTURE_PATH + ":armor/boots_electric");
+        this.itemIcon = iconRegister.registerIcon(EMT.RESOURCE_PATH + ":armor/boots_electric");
     }
 
     @Override
@@ -199,7 +199,7 @@ public class ItemElectricBootsTraveller extends ItemArmor
 
     @Override
     public String getArmorTexture(ItemStack stack, Entity entity, int slot, String type) {
-        return EMT.TEXTURE_PATH + ":textures/models/electricboots.png";
+        return EMT.RESOURCE_PATH + ":textures/models/electricboots.png";
     }
 
     @Override

--- a/src/main/java/emt/item/armor/boots/ItemNanoBootsTraveller.java
+++ b/src/main/java/emt/item/armor/boots/ItemNanoBootsTraveller.java
@@ -48,12 +48,12 @@ public class ItemNanoBootsTraveller extends ItemElectricBootsTraveller implement
     @SideOnly(Side.CLIENT)
     @Override
     public void registerIcons(IIconRegister iconRegister) {
-        this.itemIcon = iconRegister.registerIcon(EMT.TEXTURE_PATH + ":armor/boots_nano");
+        this.itemIcon = iconRegister.registerIcon(EMT.RESOURCE_PATH + ":armor/boots_nano");
     }
 
     @Override
     public String getArmorTexture(ItemStack stack, Entity entity, int slot, String type) {
-        return EMT.TEXTURE_PATH + ":textures/models/nanobootstravel.png";
+        return EMT.RESOURCE_PATH + ":textures/models/nanobootstravel.png";
     }
 
     @Override

--- a/src/main/java/emt/item/armor/boots/ItemQuantumBootsTraveller.java
+++ b/src/main/java/emt/item/armor/boots/ItemQuantumBootsTraveller.java
@@ -48,12 +48,12 @@ public class ItemQuantumBootsTraveller extends ItemElectricBootsTraveller implem
     @SideOnly(Side.CLIENT)
     @Override
     public void registerIcons(IIconRegister iconRegister) {
-        this.itemIcon = iconRegister.registerIcon(EMT.TEXTURE_PATH + ":armor/boots_quantum");
+        this.itemIcon = iconRegister.registerIcon(EMT.RESOURCE_PATH + ":armor/boots_quantum");
     }
 
     @Override
     public String getArmorTexture(ItemStack stack, Entity entity, int slot, String type) {
-        return EMT.TEXTURE_PATH + ":textures/models/quantumbootstravel.png";
+        return EMT.RESOURCE_PATH + ":textures/models/quantumbootstravel.png";
     }
 
     @Override

--- a/src/main/java/emt/item/armor/chestplate/ItemInfusedQuantumChestplate.java
+++ b/src/main/java/emt/item/armor/chestplate/ItemInfusedQuantumChestplate.java
@@ -67,11 +67,11 @@ public class ItemInfusedQuantumChestplate extends ItemArmorElectric implements I
     @SideOnly(Side.CLIENT)
     @Override
     public void registerIcons(IIconRegister iconRegister) {
-        iconNONE = iconRegister.registerIcon(EMT.TEXTURE_PATH + ":armor/armor_quantum_chest");
-        iconJETPACK = iconRegister.registerIcon(EMT.TEXTURE_PATH + ":armor/armor_quantum_chest_jetpack");
-        iconTHAUMIUM = iconRegister.registerIcon(EMT.TEXTURE_PATH + ":armor/armor_quantum_chest_wing_t");
-        iconNANO = iconRegister.registerIcon(EMT.TEXTURE_PATH + ":armor/armor_quantum_chest_wing_n");
-        iconQUANTUM = iconRegister.registerIcon(EMT.TEXTURE_PATH + ":armor/armor_quantum_chest_wing_q");
+        iconNONE = iconRegister.registerIcon(EMT.RESOURCE_PATH + ":armor/armor_quantum_chest");
+        iconJETPACK = iconRegister.registerIcon(EMT.RESOURCE_PATH + ":armor/armor_quantum_chest_jetpack");
+        iconTHAUMIUM = iconRegister.registerIcon(EMT.RESOURCE_PATH + ":armor/armor_quantum_chest_wing_t");
+        iconNANO = iconRegister.registerIcon(EMT.RESOURCE_PATH + ":armor/armor_quantum_chest_wing_n");
+        iconQUANTUM = iconRegister.registerIcon(EMT.RESOURCE_PATH + ":armor/armor_quantum_chest_wing_q");
     }
 
     @Override
@@ -356,15 +356,15 @@ public class ItemInfusedQuantumChestplate extends ItemArmorElectric implements I
 
         switch (wing) {
             case JETPACK:
-                return EMT.TEXTURE_PATH + ":textures/models/quantum_jetpack.png";
+                return EMT.RESOURCE_PATH + ":textures/models/quantum_jetpack.png";
             case THAUMIUM:
-                return EMT.TEXTURE_PATH + ":textures/models/quantum_wings_t.png";
+                return EMT.RESOURCE_PATH + ":textures/models/quantum_wings_t.png";
             case NANO:
-                return EMT.TEXTURE_PATH + ":textures/models/quantum_wings_n.png";
+                return EMT.RESOURCE_PATH + ":textures/models/quantum_wings_n.png";
             case QUANTUM:
-                return EMT.TEXTURE_PATH + ":textures/models/quantum_wings_q.png";
+                return EMT.RESOURCE_PATH + ":textures/models/quantum_wings_q.png";
             default:
-                return EMT.TEXTURE_PATH + ":textures/models/quantum.png";
+                return EMT.RESOURCE_PATH + ":textures/models/quantum.png";
         }
     }
 

--- a/src/main/java/emt/item/armor/goggles/ItemElectricGoggles.java
+++ b/src/main/java/emt/item/armor/goggles/ItemElectricGoggles.java
@@ -46,12 +46,12 @@ public class ItemElectricGoggles extends ItemArmor
     @SideOnly(Side.CLIENT)
     @Override
     public void registerIcons(IIconRegister iconRegister) {
-        this.itemIcon = iconRegister.registerIcon(EMT.TEXTURE_PATH + ":armor/goggles_electric");
+        this.itemIcon = iconRegister.registerIcon(EMT.RESOURCE_PATH + ":armor/goggles_electric");
     }
 
     @Override
     public String getArmorTexture(ItemStack stack, Entity entity, int slot, String type) {
-        return EMT.TEXTURE_PATH + ":textures/models/electricgoggles.png";
+        return EMT.RESOURCE_PATH + ":textures/models/electricgoggles.png";
     }
 
     @Override

--- a/src/main/java/emt/item/armor/goggles/ItemNanoGoggles.java
+++ b/src/main/java/emt/item/armor/goggles/ItemNanoGoggles.java
@@ -32,12 +32,12 @@ public class ItemNanoGoggles extends ItemElectricGoggles implements IHazardProte
     @SideOnly(Side.CLIENT)
     @Override
     public void registerIcons(IIconRegister iconRegister) {
-        this.itemIcon = iconRegister.registerIcon(EMT.TEXTURE_PATH + ":armor/goggles_nano");
+        this.itemIcon = iconRegister.registerIcon(EMT.RESOURCE_PATH + ":armor/goggles_nano");
     }
 
     @Override
     public String getArmorTexture(ItemStack stack, Entity entity, int slot, String type) {
-        return EMT.TEXTURE_PATH + ":textures/models/thaumicnanohelmet.png";
+        return EMT.RESOURCE_PATH + ":textures/models/thaumicnanohelmet.png";
     }
 
     @Override

--- a/src/main/java/emt/item/armor/goggles/ItemQuantumGoggles.java
+++ b/src/main/java/emt/item/armor/goggles/ItemQuantumGoggles.java
@@ -42,12 +42,12 @@ public class ItemQuantumGoggles extends ItemNanoGoggles {
     @SideOnly(Side.CLIENT)
     @Override
     public void registerIcons(IIconRegister iconRegister) {
-        this.itemIcon = iconRegister.registerIcon(EMT.TEXTURE_PATH + ":armor/goggles_quantum");
+        this.itemIcon = iconRegister.registerIcon(EMT.RESOURCE_PATH + ":armor/goggles_quantum");
     }
 
     @Override
     public String getArmorTexture(ItemStack stack, Entity entity, int slot, String type) {
-        return EMT.TEXTURE_PATH + ":textures/models/thaumicquantumhelmet.png";
+        return EMT.RESOURCE_PATH + ":textures/models/thaumicquantumhelmet.png";
     }
 
     @Override

--- a/src/main/java/emt/item/armor/goggles/ItemSolarHelmetRevealing.java
+++ b/src/main/java/emt/item/armor/goggles/ItemSolarHelmetRevealing.java
@@ -48,12 +48,12 @@ public class ItemSolarHelmetRevealing extends ItemQuantumGoggles {
     @SideOnly(Side.CLIENT)
     @Override
     public void registerIcons(IIconRegister iconRegister) {
-        this.itemIcon = iconRegister.registerIcon(EMT.TEXTURE_PATH + ":armor/goggles_solar");
+        this.itemIcon = iconRegister.registerIcon(EMT.RESOURCE_PATH + ":armor/goggles_solar");
     }
 
     @Override
     public String getArmorTexture(ItemStack stack, Entity entity, int slot, String layerType) {
-        return EMT.TEXTURE_PATH + ":textures/models/solarrevealinghelmet.png";
+        return EMT.RESOURCE_PATH + ":textures/models/solarrevealinghelmet.png";
     }
 
     @Override

--- a/src/main/java/emt/item/armor/wings/ItemFeatherWing.java
+++ b/src/main/java/emt/item/armor/wings/ItemFeatherWing.java
@@ -39,13 +39,13 @@ public class ItemFeatherWing extends ItemArmor implements IRunicArmor {
     @SideOnly(Side.CLIENT)
     @Override
     public void registerIcons(IIconRegister iconRegister) {
-        this.itemIcon = iconRegister.registerIcon(EMT.TEXTURE_PATH + ":armor/wing_feather");
+        this.itemIcon = iconRegister.registerIcon(EMT.RESOURCE_PATH + ":armor/wing_feather");
     }
 
     @Override
     @SideOnly(Side.CLIENT)
     public String getArmorTexture(ItemStack stack, Entity entity, int slot, String type) {
-        return EMT.TEXTURE_PATH + ":textures/models/featherwing.png";
+        return EMT.RESOURCE_PATH + ":textures/models/featherwing.png";
     }
 
     @Override

--- a/src/main/java/emt/item/armor/wings/ItemNanoWing.java
+++ b/src/main/java/emt/item/armor/wings/ItemNanoWing.java
@@ -50,7 +50,7 @@ public class ItemNanoWing extends ItemThaumiumReinforcedWing
     @SideOnly(Side.CLIENT)
     @Override
     public void registerIcons(IIconRegister iconRegister) {
-        this.itemIcon = iconRegister.registerIcon(EMT.TEXTURE_PATH + ":armor/wing_nano");
+        this.itemIcon = iconRegister.registerIcon(EMT.RESOURCE_PATH + ":armor/wing_nano");
     }
 
     @SideOnly(Side.CLIENT)
@@ -69,7 +69,7 @@ public class ItemNanoWing extends ItemThaumiumReinforcedWing
     @Override
     @SideOnly(Side.CLIENT)
     public String getArmorTexture(ItemStack stack, Entity entity, int slot, String type) {
-        return EMT.TEXTURE_PATH + ":textures/models/nanowing.png";
+        return EMT.RESOURCE_PATH + ":textures/models/nanowing.png";
     }
 
     @Override

--- a/src/main/java/emt/item/armor/wings/ItemQuantumWing.java
+++ b/src/main/java/emt/item/armor/wings/ItemQuantumWing.java
@@ -33,13 +33,13 @@ public class ItemQuantumWing extends ItemNanoWing {
     @SideOnly(Side.CLIENT)
     @Override
     public void registerIcons(IIconRegister iconRegister) {
-        this.itemIcon = iconRegister.registerIcon(EMT.TEXTURE_PATH + ":armor/wing_quantum");
+        this.itemIcon = iconRegister.registerIcon(EMT.RESOURCE_PATH + ":armor/wing_quantum");
     }
 
     @Override
     @SideOnly(Side.CLIENT)
     public String getArmorTexture(ItemStack stack, Entity entity, int slot, String type) {
-        return EMT.TEXTURE_PATH + ":textures/models/quantumwing.png";
+        return EMT.RESOURCE_PATH + ":textures/models/quantumwing.png";
     }
 
     @Override

--- a/src/main/java/emt/item/armor/wings/ItemThaumiumReinforcedWing.java
+++ b/src/main/java/emt/item/armor/wings/ItemThaumiumReinforcedWing.java
@@ -40,13 +40,13 @@ public class ItemThaumiumReinforcedWing extends ItemFeatherWing implements IVisD
     @SideOnly(Side.CLIENT)
     @Override
     public void registerIcons(IIconRegister iconRegister) {
-        this.itemIcon = iconRegister.registerIcon(EMT.TEXTURE_PATH + ":armor/wing_thaumium");
+        this.itemIcon = iconRegister.registerIcon(EMT.RESOURCE_PATH + ":armor/wing_thaumium");
     }
 
     @Override
     @SideOnly(Side.CLIENT)
     public String getArmorTexture(ItemStack stack, Entity entity, int slot, String type) {
-        return EMT.TEXTURE_PATH + ":textures/models/thaumiumwing.png";
+        return EMT.RESOURCE_PATH + ":textures/models/thaumiumwing.png";
     }
 
     @Override

--- a/src/main/java/emt/item/block/ItemBlockElectricCloud.java
+++ b/src/main/java/emt/item/block/ItemBlockElectricCloud.java
@@ -25,7 +25,7 @@ public class ItemBlockElectricCloud extends ItemBlock {
 
     @Override
     public void registerIcons(IIconRegister ir) {
-        icon = ir.registerIcon(EMT.TEXTURE_PATH + ":" + "electric_cloud");
+        icon = ir.registerIcon(EMT.RESOURCE_PATH + ":" + "electric_cloud");
     }
 
     @Override

--- a/src/main/java/emt/item/focus/ItemBaseFocus.java
+++ b/src/main/java/emt/item/focus/ItemBaseFocus.java
@@ -31,7 +31,7 @@ public abstract class ItemBaseFocus extends ItemFocusBasic {
 
     @SideOnly(Side.CLIENT)
     public void registerIcons(IIconRegister ir) {
-        this.icon = ir.registerIcon(EMT.TEXTURE_PATH + ":" + "focus_" + textureName);
+        this.icon = ir.registerIcon(EMT.RESOURCE_PATH + ":" + "focus_" + textureName);
     }
 
     @Override

--- a/src/main/java/emt/item/tool/ItemElectricHoeGrowth.java
+++ b/src/main/java/emt/item/tool/ItemElectricHoeGrowth.java
@@ -39,7 +39,7 @@ public class ItemElectricHoeGrowth extends ItemHoe implements IElectricItem {
 
     @SideOnly(Side.CLIENT)
     public void registerIcons(IIconRegister iconRegister) {
-        this.icon = iconRegister.registerIcon(EMT.TEXTURE_PATH + ":tools/hoe_growth");
+        this.icon = iconRegister.registerIcon(EMT.RESOURCE_PATH + ":tools/hoe_growth");
     }
 
     @SideOnly(Side.CLIENT)

--- a/src/main/java/emt/item/tool/ItemElectricThorHammer.java
+++ b/src/main/java/emt/item/tool/ItemElectricThorHammer.java
@@ -41,7 +41,7 @@ public class ItemElectricThorHammer extends ItemSword implements IElectricItem {
     @SideOnly(Side.CLIENT)
     @Override
     public void registerIcons(IIconRegister iconRegister) {
-        this.itemIcon = iconRegister.registerIcon(EMT.TEXTURE_PATH + ":hammer/electricthorhammer");
+        this.itemIcon = iconRegister.registerIcon(EMT.RESOURCE_PATH + ":hammer/electricthorhammer");
     }
 
     @SideOnly(Side.CLIENT)

--- a/src/main/java/emt/item/tool/ItemThorHammer.java
+++ b/src/main/java/emt/item/tool/ItemThorHammer.java
@@ -33,7 +33,7 @@ public class ItemThorHammer extends ItemSword implements IRepairable {
     @SideOnly(Side.CLIENT)
     @Override
     public void registerIcons(IIconRegister iconRegister) {
-        this.itemIcon = iconRegister.registerIcon(EMT.TEXTURE_PATH + ":hammer/thorhammer");
+        this.itemIcon = iconRegister.registerIcon(EMT.RESOURCE_PATH + ":hammer/thorhammer");
     }
 
     @Override

--- a/src/main/java/emt/item/tool/ItemThorHammerBroken.java
+++ b/src/main/java/emt/item/tool/ItemThorHammerBroken.java
@@ -30,7 +30,7 @@ public class ItemThorHammerBroken extends ItemSword implements IRepairable {
     @SideOnly(Side.CLIENT)
     @Override
     public void registerIcons(IIconRegister iconRegister) {
-        this.itemIcon = iconRegister.registerIcon(EMT.TEXTURE_PATH + ":hammer/taintedthorhammer");
+        this.itemIcon = iconRegister.registerIcon(EMT.RESOURCE_PATH + ":hammer/taintedthorhammer");
     }
 
     @Override

--- a/src/main/java/emt/item/tool/chainsaw/ItemDiamondChainsaw.java
+++ b/src/main/java/emt/item/tool/chainsaw/ItemDiamondChainsaw.java
@@ -54,7 +54,7 @@ public class ItemDiamondChainsaw extends ItemAxe implements IElectricItem {
     @SideOnly(Side.CLIENT)
     @Override
     public void registerIcons(IIconRegister iconRegister) {
-        this.itemIcon = iconRegister.registerIcon(EMT.TEXTURE_PATH + ":tools/chainsaw_diamond");
+        this.itemIcon = iconRegister.registerIcon(EMT.RESOURCE_PATH + ":tools/chainsaw_diamond");
     }
 
     @Override

--- a/src/main/java/emt/item/tool/chainsaw/ItemStreamChainsaw.java
+++ b/src/main/java/emt/item/tool/chainsaw/ItemStreamChainsaw.java
@@ -42,7 +42,7 @@ public class ItemStreamChainsaw extends ItemThaumiumChainsaw {
     @SideOnly(Side.CLIENT)
     @Override
     public void registerIcons(IIconRegister iconRegister) {
-        this.itemIcon = iconRegister.registerIcon(EMT.TEXTURE_PATH + ":tools/chainsaw_stream");
+        this.itemIcon = iconRegister.registerIcon(EMT.RESOURCE_PATH + ":tools/chainsaw_stream");
     }
 
     @Override

--- a/src/main/java/emt/item/tool/chainsaw/ItemThaumiumChainsaw.java
+++ b/src/main/java/emt/item/tool/chainsaw/ItemThaumiumChainsaw.java
@@ -28,7 +28,7 @@ public class ItemThaumiumChainsaw extends ItemDiamondChainsaw {
     @SideOnly(Side.CLIENT)
     @Override
     public void registerIcons(IIconRegister iconRegister) {
-        this.itemIcon = iconRegister.registerIcon(EMT.TEXTURE_PATH + ":tools/chainsaw_thaumium");
+        this.itemIcon = iconRegister.registerIcon(EMT.RESOURCE_PATH + ":tools/chainsaw_thaumium");
     }
 
     @Override

--- a/src/main/java/emt/item/tool/drill/ItemRockbreakerDrill.java
+++ b/src/main/java/emt/item/tool/drill/ItemRockbreakerDrill.java
@@ -62,7 +62,7 @@ public class ItemRockbreakerDrill extends ItemThaumiumDrill {
     @SideOnly(Side.CLIENT)
     @Override
     public void registerIcons(IIconRegister iconRegister) {
-        this.itemIcon = iconRegister.registerIcon(EMT.TEXTURE_PATH + ":tools/drill_rockbreaker");
+        this.itemIcon = iconRegister.registerIcon(EMT.RESOURCE_PATH + ":tools/drill_rockbreaker");
     }
 
     private boolean isEffectiveAgainst(Block block) {

--- a/src/main/java/emt/item/tool/drill/ItemThaumiumDrill.java
+++ b/src/main/java/emt/item/tool/drill/ItemThaumiumDrill.java
@@ -43,7 +43,7 @@ public class ItemThaumiumDrill extends ItemPickaxe implements IElectricItem {
     @SideOnly(Side.CLIENT)
     @Override
     public void registerIcons(IIconRegister iconRegister) {
-        this.itemIcon = iconRegister.registerIcon(EMT.TEXTURE_PATH + ":tools/drill_thaumium");
+        this.itemIcon = iconRegister.registerIcon(EMT.RESOURCE_PATH + ":tools/drill_thaumium");
     }
 
     @SideOnly(Side.CLIENT)

--- a/src/main/java/emt/item/tool/omnitool/ItemOmnitoolDiamond.java
+++ b/src/main/java/emt/item/tool/omnitool/ItemOmnitoolDiamond.java
@@ -33,7 +33,7 @@ public class ItemOmnitoolDiamond extends ItemOmnitoolIron {
     @SideOnly(Side.CLIENT)
     @Override
     public void registerIcons(IIconRegister iconRegister) {
-        this.itemIcon = iconRegister.registerIcon(EMT.TEXTURE_PATH + ":tools/omnitool_diamond");
+        this.itemIcon = iconRegister.registerIcon(EMT.RESOURCE_PATH + ":tools/omnitool_diamond");
     }
 
     @Override

--- a/src/main/java/emt/item/tool/omnitool/ItemOmnitoolIron.java
+++ b/src/main/java/emt/item/tool/omnitool/ItemOmnitoolIron.java
@@ -46,7 +46,7 @@ public class ItemOmnitoolIron extends ItemPickaxe implements IElectricItem {
     @SideOnly(Side.CLIENT)
     @Override
     public void registerIcons(IIconRegister iconRegister) {
-        this.itemIcon = iconRegister.registerIcon(EMT.TEXTURE_PATH + ":tools/omnitool_iron");
+        this.itemIcon = iconRegister.registerIcon(EMT.RESOURCE_PATH + ":tools/omnitool_iron");
     }
 
     @SideOnly(Side.CLIENT)

--- a/src/main/java/emt/item/tool/omnitool/ItemOmnitoolThaumium.java
+++ b/src/main/java/emt/item/tool/omnitool/ItemOmnitoolThaumium.java
@@ -33,7 +33,7 @@ public class ItemOmnitoolThaumium extends ItemOmnitoolDiamond {
     @SideOnly(Side.CLIENT)
     @Override
     public void registerIcons(IIconRegister iconRegister) {
-        this.itemIcon = iconRegister.registerIcon(EMT.TEXTURE_PATH + ":tools/omnitool_thaumium");
+        this.itemIcon = iconRegister.registerIcon(EMT.RESOURCE_PATH + ":tools/omnitool_thaumium");
     }
 
     @Override


### PR DESCRIPTION
After PR #100 `EMT.TEXTURE_PATH` is now a direct copy of `EMT.RESOURCE_PATH` and thus redundant. I didn't want to bloat the other PR with changes to unrelated files, so here's a separate one that replaces the old refs with new ones.