### PR TITLE
Fix Electric Goggles taking durability damage when they shouldn't

### DIFF
--- a/src/main/java/emt/item/armor/goggles/ItemElectricGoggles.java
+++ b/src/main/java/emt/item/armor/goggles/ItemElectricGoggles.java
@@ -43,6 +43,9 @@ public class ItemElectricGoggles extends ItemArmor
         this.setCreativeTab(EMT.TAB);
     }
 
+    @Override
+    public void setDamage(ItemStack stack, int damage) {}
+
     @SideOnly(Side.CLIENT)
     @Override
     public void registerIcons(IIconRegister iconRegister) {

--- a/src/main/java/emt/util/EMTEventHandler.java
+++ b/src/main/java/emt/util/EMTEventHandler.java
@@ -20,7 +20,6 @@ import cpw.mods.fml.common.gameevent.TickEvent.Phase;
 import emt.EMT;
 import emt.init.EMTBlocks;
 import emt.init.EMTItems;
-import emt.item.armor.goggles.ItemElectricGoggles;
 import emt.item.armor.wings.ItemFeatherWing;
 import ic2.api.item.ElectricItem;
 import thaumcraft.common.config.ConfigBlocks;
@@ -44,34 +43,15 @@ public class EMTEventHandler {
      */
     @SubscribeEvent
     public void onLivingHurt(LivingHurtEvent e) {
-        if (!(e.entityLiving instanceof EntityPlayer player)) {
+        if (!(e.entityLiving instanceof EntityPlayer) || e.source != DamageSource.fall) return;
+
+        ItemStack s = ((EntityPlayer) e.entityLiving).inventory.armorInventory[2];
+
+        if (s == null || !(s.getItem() instanceof ItemFeatherWing)) {
             return;
         }
 
-        if (e.source == DamageSource.fall) {
-            ItemStack chestplate = player.inventory.armorInventory[2];
-            if (chestplate != null && chestplate.getItem() instanceof ItemFeatherWing) {
-                e.ammount *= ((ItemFeatherWing) chestplate.getItem()).getFallDamageMult();
-            }
-        }
-
-        else if (e.source == DamageSource.anvil || e.source == DamageSource.fallingBlock) {
-            ItemStack helmet = player.getEquipmentInSlot(4); // 4 for Helmet
-
-            if (helmet != null && helmet.getItem() instanceof ItemElectricGoggles goggles) {
-                double energyRequired = e.ammount * goggles.getEnergyPerDamage();
-                double currentEnergy = ElectricItem.manager.getCharge(helmet);
-
-                if (currentEnergy >= energyRequired) {
-                    ElectricItem.manager.discharge(helmet, energyRequired, Integer.MAX_VALUE, true, false, false);
-                    e.setCanceled(true);
-                } else if (currentEnergy > 0) {
-                    float damageAbsorbed = (float) (currentEnergy / goggles.getEnergyPerDamage());
-                    ElectricItem.manager.discharge(helmet, currentEnergy, Integer.MAX_VALUE, true, false, false);
-                    e.ammount -= damageAbsorbed;
-                }
-            }
-        }
+        e.ammount *= ((ItemFeatherWing) s.getItem()).getFallDamageMult();
     }
 
     @SubscribeEvent

--- a/src/main/java/emt/util/EMTEventHandler.java
+++ b/src/main/java/emt/util/EMTEventHandler.java
@@ -28,18 +28,9 @@ import thaumcraft.common.entities.monster.EntityTaintChicken;
 public class EMTEventHandler {
 
     /**
-     * Intercepts damage events for any living entity to apply custom effects for players wearing specific armor. This
-     * method is a central handler for armor-based damage mitigation that cannot be handled by the ISpecialArmor
-     * interface.
-     * <p>
-     * It triggers whenever an entity is about to be hurt and contains two primary logic blocks:
-     * <ol>
-     * <li>Reduces fall damage for players wearing Feather Wings.</li>
-     * <li>Absorbs anvil/falling block damage for players wearing Electric Goggles, preventing the item from breaking
-     * due to a hardcoded vanilla mechanic.</li>
-     * </ol>
-     *
-     * @param e The LivingHurtEvent, containing information about the damage source, amount, and the entity being hurt.
+     * Intercept the onLivingHurt event so that we can mitigate fall damage with feather wings
+     * 
+     * @param e Entity that is being damaged
      */
     @SubscribeEvent
     public void onLivingHurt(LivingHurtEvent e) {


### PR DESCRIPTION
This PR reverts [#102 ](https://github.com/GTNewHorizons/Electro-Magic-Tools/pull/102) which I reviewed and merged as it didn't completely address the issue and could be simplified to a simple override in `ItemElectricGoggles`.

We now just override `setDamage` so it does nothing and therefore no durability damage is applied.