### PR TITLE
Fix(ItemElectricGoggles): ic2 energy bar not being displayed nor updated

### DIFF
--- a/src/main/java/emt/item/armor/goggles/ItemElectricGoggles.java
+++ b/src/main/java/emt/item/armor/goggles/ItemElectricGoggles.java
@@ -43,8 +43,27 @@ public class ItemElectricGoggles extends ItemArmor
         this.setCreativeTab(EMT.TAB);
     }
 
+    /**
+     * Allow damage to be set to avoid breaking IC2 Energy bar or other features, while preventing the item from
+     * breaking.
+     *
+     * @param stack  the item stack
+     * @param damage the new damage value
+     */
     @Override
-    public void setDamage(ItemStack stack, int damage) {}
+    public void setDamage(ItemStack stack, int damage) {
+        int max = stack.getMaxDamage();
+
+        if (max > 0) {
+            if (damage >= max) {
+                damage = max - 1;
+            } else if (damage < 0) {
+                damage = 0;
+            }
+        }
+
+        super.setDamage(stack, damage);
+    }
 
     @SideOnly(Side.CLIENT)
     @Override


### PR DESCRIPTION
Fixes bug introduced in https://github.com/GTNewHorizons/Electro-Magic-Tools/pull/103 where the item energy bar and meta (aka damage) doesn't get updated any more:

<img width="440" height="110" alt="image" src="https://github.com/user-attachments/assets/d7dc71fd-4e02-4713-8586-ea8dfd603154" />

After PR:
<img width="470" height="112" alt="image" src="https://github.com/user-attachments/assets/7a676c3e-2be1-4c83-8737-20bbad4af590" />
