### PR TITLE
Fix EMT machines dropping wrong items when broken

### DIFF
--- a/src/main/java/emt/block/BlockBaseContainer.java
+++ b/src/main/java/emt/block/BlockBaseContainer.java
@@ -76,7 +76,7 @@ public abstract class BlockBaseContainer extends BlockContainer {
             return set.bottom;
         } else if (side == 1) {
             return set.top;
-        } else if (side != tile.facing) {
+        } else if (tile == null || side != tile.facing) {
             return set.side;
         } else if (tile.isOn) {
             if (set.frontOn != null) {

--- a/src/main/java/emt/block/BlockBaseContainer.java
+++ b/src/main/java/emt/block/BlockBaseContainer.java
@@ -3,6 +3,7 @@ package emt.block;
 import net.minecraft.block.BlockContainer;
 import net.minecraft.block.material.Material;
 import net.minecraft.entity.EntityLivingBase;
+import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
 import net.minecraft.util.IIcon;
@@ -40,6 +41,7 @@ public abstract class BlockBaseContainer extends BlockContainer {
         this.setCreativeTab(EMT.TAB);
         this.setStepSound(soundType);
         this.setHardness(hardness);
+        setHarvestLevel("wrench", 1);
 
         this.countOfMetas = countOfMetas;
         this.instance = curInstance;
@@ -141,6 +143,11 @@ public abstract class BlockBaseContainer extends BlockContainer {
                 tile.facing = 4;
                 break;
         }
+    }
+
+    @Override
+    public boolean canHarvestBlock(EntityPlayer player, int meta) {
+        return true;
     }
 
     @Override

--- a/src/main/java/emt/block/BlockMachines.java
+++ b/src/main/java/emt/block/BlockMachines.java
@@ -23,12 +23,17 @@ import cpw.mods.fml.relauncher.SideOnly;
 import emt.EMT;
 import emt.tile.TileEntityEtherealMacerator;
 import emt.tile.TileEntityIndustrialWandRecharge;
-import ic2.api.item.IC2Items;
 
 public class BlockMachines extends BlockBaseContainer {
 
     public BlockMachines(String name) {
         super(name, Material.iron, soundTypeMetal, 3, 4.0F);
+        setHarvestLevel("wrench", 1);
+    }
+
+    @Override
+    public boolean canHarvestBlock(EntityPlayer player, int meta) {
+        return true;
     }
 
     @Override
@@ -90,7 +95,7 @@ public class BlockMachines extends BlockBaseContainer {
 
     @Override
     public Item getItemDropped(int meta, Random random, int fortune) {
-        return IC2Items.getItem("machine").getItem();
+        return Item.getItemFromBlock(this);
     }
 
     @Override

--- a/src/main/java/emt/block/BlockMachines.java
+++ b/src/main/java/emt/block/BlockMachines.java
@@ -28,12 +28,6 @@ public class BlockMachines extends BlockBaseContainer {
 
     public BlockMachines(String name) {
         super(name, Material.iron, soundTypeMetal, 3, 4.0F);
-        setHarvestLevel("wrench", 1);
-    }
-
-    @Override
-    public boolean canHarvestBlock(EntityPlayer player, int meta) {
-        return true;
     }
 
     @Override


### PR DESCRIPTION
EMT machine blocks Industrial Wand Charging Station, Ethereal Processor, Essentia Filler dropped an IC2 Basic Machine Casing instead of themselves when broken.

Additionally, a null check was added in BlockBaseContainer.getIcon() to prevent a crash when rendering blocks without a tile entity.

The EMT machines can now be broken using GT wrenches.

Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/23790
Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/24302
Closes https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/issues/20819