### PR TITLE
deprecate ic2 bounce pad

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -11,5 +11,5 @@ dependencies {
     api('net.industrial-craft:industrialcraft-2:2.2.828-experimental:dev')
     api('thaumcraft:Thaumcraft:1.7.10-4.2.3.5:dev')
 
-    compileOnly('com.github.GTNewHorizons:GT5-Unofficial:5.09.53.02:dev')
+    compileOnly('com.github.GTNewHorizons:GT5-Unofficial:5.09.53.05:dev')
 }

--- a/src/main/java/emt/gthandler/common/loader/EMT_GT_Loader.java
+++ b/src/main/java/emt/gthandler/common/loader/EMT_GT_Loader.java
@@ -32,5 +32,6 @@ public class EMT_GT_Loader {
         registerObjectTag(
                 ItemList.FenceIron.get(1L),
                 new AspectList().add(Aspect.ENERGY, 1).add(Aspect.METAL, 2).add(Aspect.WEATHER, 1));
+        registerObjectTag(ItemList.PadBouncy.get(1L), new AspectList().add(Aspect.AIR, 5));
     }
 }

--- a/src/main/java/emt/gthandler/common/loader/EMT_GT_Loader.java
+++ b/src/main/java/emt/gthandler/common/loader/EMT_GT_Loader.java
@@ -33,5 +33,6 @@ public class EMT_GT_Loader {
                 ItemList.FenceIron.get(1L),
                 new AspectList().add(Aspect.ENERGY, 1).add(Aspect.METAL, 2).add(Aspect.WEATHER, 1));
         registerObjectTag(ItemList.PadBouncy.get(1L), new AspectList().add(Aspect.AIR, 5));
+        registerObjectTag(ItemList.PadSticky.get(1L), new AspectList().add(Aspect.TRAP, 5).add(Aspect.SLIME, 2));
     }
 }

--- a/src/main/java/emt/init/EMTBlocks.java
+++ b/src/main/java/emt/init/EMTBlocks.java
@@ -47,7 +47,6 @@ public class EMTBlocks {
     }
 
     public static void addAspects() {
-        registerObjectTag(IC2Items.getItem("rubberTrampoline"), new AspectList().add(Aspect.AIR, 5));
         registerObjectTag(
                 IC2Items.getItem("reinforcedGlass"),
                 new AspectList().add(Aspect.METAL, 2).add(Aspect.COLD, 2));


### PR DESCRIPTION
depends on https://github.com/GTNewHorizons/GT5-Unofficial/pull/7212/


move bounce pad aspect registry